### PR TITLE
Remove IMAGE_NAME and IMAGE_TAG parameters

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,7 +120,6 @@ jobs:
                 -p APP_NAME=forms-flow-ai \
                 -p NAME=${APP} \
                 -p IMAGE_NAMESPACE=${BUILD_NAMESPACE} \
-                -p IMAGE_NAME=forms-flow-web \
                 -p TAG_NAME=latest \
                 -p CPU_REQUEST=100m \
                 -p CPU_LIMIT=250m \
@@ -175,8 +174,7 @@ jobs:
           oc -n ${NAMESPACE} process -f deployment/openshift/webapi_dc.yaml \
                 -p NAME=${API} \
                 -p IMAGE_NAMESPACE=${BUILD_NAMESPACE} \
-                -p IMAGE_NAME=forms-flow-webapi \
-                -p IMAGE_TAG=latest \
+                -p TAG_NAME=latest \
                 -p CPU_REQUEST=100m \
                 -p CPU_LIMIT=250m \
                 -p MEMORY_REQUEST=100Mi \


### PR DESCRIPTION
## Summary

The PR removes redundant parameters IMAGE_NAME and IMAGE_TAG from the Github workflow deploy.yaml


## Changes
- Remove IMAGE_NAME and IMAGE_TAG parameters


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->