### PR TITLE
Remove IMAGE_TAG from web api deployment template

### DIFF
--- a/deployment/openshift/webapi_dc.yaml
+++ b/deployment/openshift/webapi_dc.yaml
@@ -200,9 +200,6 @@ parameters:
       server instance.
     required: true
     value: forms-flow-webapi
-  - name: IMAGE_TAG
-    description: The image tag to pull for the deployment.
-    required: true  
   - name: IMAGE_NAMESPACE
     displayName: Image Namespace
     required: true


### PR DESCRIPTION
## Summary

Remove IMAGE_TAG parameter from web api deployment template as well.
