### PR TITLE
fixing filter url, removing errors on FE

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/employeeDataService.py
+++ b/forms-flow-api/src/formsflow_api/services/employeeDataService.py
@@ -14,7 +14,7 @@ class EmployeeDataService:
           "EMPLOYEE_DATA_AUTH_TOKEN")
 
       try:
-        response_from_BCGov = requests.get("{}?filter=GUID eq '{}'".format(employee_data_api_url, guid),
+        response_from_BCGov = requests.get("{}?$filter=GUID eq '{}'".format(employee_data_api_url, guid),
                        headers={"Authorization": test_auth_token})
       except:
         return {"message": "Something went wrong!"}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -171,7 +171,7 @@ const mapStateToProps = (state) => {
     user: state.user.userDetail,
     form: selectRoot("form", state),
     isAuthenticated: state.user.isAuthenticated,
-    errors: [selectError("form", state), selectError("submission", state), state.employeeData.error],
+    errors: [selectError("form", state), selectError("submission", state)],
     options: {
       noAlerts: false,
       i18n: {


### PR DESCRIPTION
## Summary
This pr fixes the issue with the slow employee data fetch. I missed `$` in the URL param which made it fetch data for all users.

Also, stop showing employee data fetch error on FE as this is optional and should not keep users from entering the form if don't have GUID or no data available in ODS yet (for the user).