### PR TITLE
make the fieldset border invisible

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -774,3 +774,7 @@ header span:hover {
 i.fa.fa-question-circle.text-muted {
   color: $linkColor !important;
 }
+
+fieldset {
+  border: 0px !important;
+}


### PR DESCRIPTION
## Summary

A CSS class that make the fieldset border invisible

## Screenshots (if applicable)
<img width="1422" alt="Screen Shot 2022-03-03 at 2 11 28 PM" src="https://user-images.githubusercontent.com/77303486/156661368-a800e07e-5c30-4c30-8847-c56a758f2295.png">
