### PR TITLE
Add missing pipe at the end of oc process command

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -137,7 +137,7 @@ jobs:
                 -p CPU_LIMIT=250m \
                 -p MEMORY_REQUEST=100Mi \
                 -p MEMORY_LIMIT=2Gi \
-                -p FFAWEB_URL="${{secrets.FFAWEB_URL}}"
+                -p FFAWEB_URL="${{secrets.FFAWEB_URL}}" | \
           oc -n ${NAMESPACE} apply -f -
 
           # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.
@@ -232,7 +232,7 @@ jobs:
                 -p CPU_LIMIT=250m \
                 -p MEMORY_REQUEST=100Mi \
                 -p MEMORY_LIMIT=2Gi \
-                -p FFAWEB_URL="${{secrets.FFAWEB_URL}}"
+                -p FFAWEB_URL="${{secrets.FFAWEB_URL}}" | \
           oc -n ${NAMESPACE} apply -f -
           #oc rollout latest dc/"${APP}" -n ${NAMESPACE}
           # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.


### PR DESCRIPTION
## Summary

Fix pipeline error - "No objects past to apply" . Added the trailing pipe ("|") to the "oc process" command.

## Changes
Added the trailing pipe ("|") to the "oc process" command.

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->