### PR TITLE
DGJ-94 Fix upload of files after removing old one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Lifecycle:Maturing](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/digital-journeys)
+
 <div id="top"></div>
 
 <!-- PROJECT LOGO -->

--- a/deployment/openshift/web_config.yaml
+++ b/deployment/openshift/web_config.yaml
@@ -39,7 +39,8 @@ objects:
             "REACT_APP_APPLICATION_NAME": "${REACT_APP_APPLICATION_NAME}",
             "REACT_APP_WEB_BASE_CUSTOM_URL": "${REACT_APP_WEB_BASE_CUSTOM_URL}",
             "REACT_APP_FORMIO_JWT_SECRET": "${REACT_APP_FORMIO_JWT_SECRET}",
-            "REACT_APP_USER_ACCESS_PERMISSIONS": '${REACT_APP_USER_ACCESS_PERMISSIONS}'
+            "REACT_APP_USER_ACCESS_PERMISSIONS": '${REACT_APP_USER_ACCESS_PERMISSIONS}',
+            "REACT_APP_FORMIO_FILE_URL": "${REACT_APP_FORMIO_FILE_URL}"
           }
   -
     apiVersion: v1
@@ -134,6 +135,10 @@ parameters:
     description:
       Route to access Forms Flow AI Web site
     required: true
+  - name: REACT_APP_FORMIO_FILE_URL
+    displayName: REACT_APP_FORMIO_FILE_URL
+    description:
+      Route to access Formio file upload server
   - name: REACT_APP_WEBSOCKET_ENCRYPT_KEY
     displayName: REACT_APP_WEBSOCKET_ENCRYPT_KEY
     description:

--- a/forms-flow-api/entrypoint.dev
+++ b/forms-flow-api/entrypoint.dev
@@ -1,2 +1,2 @@
 #!/bin/bash
-python manage.py db upgrade && gunicorn -b :5000 'formsflow_api:create_app()' --timeout 120 --worker-class=gthread --workers=1 --threads=1 --reload
+python manage.py db upgrade && gunicorn -b :5000 'formsflow_api:create_app()' --timeout 120 --worker-class=gthread --workers=2 --threads=2 --reload

--- a/forms-flow-api/src/formsflow_api/services/employeeDataService.py
+++ b/forms-flow-api/src/formsflow_api/services/employeeDataService.py
@@ -17,13 +17,12 @@ class EmployeeDataService:
         response_from_BCGov = requests.get("{}?$filter=GUID eq '{}'".format(employee_data_api_url, guid),
                        headers={"Authorization": test_auth_token})
       except:
-        return {"message": "Something went wrong!"}, HTTPStatus.INTERNAL_SERVER_ERROR
+        return {"message": "Failed to look up user in ODS"}, HTTPStatus.INTERNAL_SERVER_ERROR
       
       #TODO: check response for data and return accordingly. No all users have data
       employee_data_res = response_from_BCGov.json()
-      emp_data = EmployeeData(employee_data_res["value"][0])
 
-      return emp_data.__dict__
-      
-
-    
+      if employee_data_res and employee_data_res["value"] and len(employee_data_res["value"]) > 0:
+        emp_data = EmployeeData(employee_data_res["value"][0])
+        return emp_data.__dict__, HTTPStatus
+      return {"message": "No user data found"}, HTTPStatus.NOT_FOUND

--- a/forms-flow-web/src/formComponents/FileUpload/index.js
+++ b/forms-flow-web/src/formComponents/FileUpload/index.js
@@ -41,4 +41,20 @@ export default class DGJFileUpload extends FileComponent{
       schema: DGJFileUpload.schema(),
     };
   }
+
+  // Fix a bug where the file upload component doesn't display if you remove a file that had an error
+  attach(element) {
+    this.loadRefs(element, {
+      fileStatusRemove: 'multiple',
+    });
+
+    this.refs.fileStatusRemove.forEach((fileStatusRemove, index) => {
+      this.addEventListener(fileStatusRemove, 'click', (event) => {
+        // Force the file selector component to show once the errored file has been removed
+        this.fileDropHidden = false;
+      });
+    });
+
+    return super.attach(element);
+  }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where you couldn't re-upload a new file after removing a file that was too big. Also fixed an issue where form submissions would time out when running the app locally (CC/ @iman-jamali-fw, think this fixes the issue you experienced), and handling a user that doesn't exist in the ODS gracefully instead of producing a 500 error. 
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow. 

-->

## Changes
- Added event listener to all `fileStatusRemove` elements that on click shows the file upload component again
- Added lifecycle badge to the repo (required for all BCGov repos)
- Increased # threads for running the WebAPI locally to avoid deadlock that happens when submitting the form
- Return `400` instead of `500` if you look up a user that doesn't existing in the ODS
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/66635118/157343073-57af3bd0-163b-46ea-815d-8f88ab132c86.png)

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->