### PR TITLE
hotfix/DGJ-90_form-data-reset-on-auth-token-refresh

### DIFF
--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
 import {
   selectRoot,
@@ -44,6 +44,8 @@ const View = React.memo((props) => {
   } = props;
   const dispatch = useDispatch();
 
+  const [isInitialDataSet, setIsInitialDataSet] = useState(false)
+
   useEffect(() => {
     if (!isAuthenticated) {
       getForm();
@@ -64,7 +66,7 @@ const View = React.memo((props) => {
   const getDefaultValues = (data) => {
     if (
       Object.keys(data).length === 0 ||
-      form.components.length === 0) {
+      form.components.length === 0 || isInitialDataSet) {
       return;
     }
 
@@ -109,6 +111,8 @@ const View = React.memo((props) => {
     });
 
     const defaultValuesObject = defaultValuesArray?.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+    setIsInitialDataSet(true);
 
     return { data: defaultValuesObject };
   };


### PR DESCRIPTION
## Summary
The issue with form data reset on auth token reset fixed with a flag to prevent the form from resetting values on reRender.

## Changes
A flag was set in the `View` component to prevent the form from subsequent auto-populating data.

## Notes
What was the issue?
The real cause of the issue is that the `View` component re-renders on auth toke refresh which is every 5 mins. This forces the auto-populate function to reset the form's data values.

What could be the root cause of the issue?
My investigation shows that only the `View` component rerenders. I tried to trace the cause of the issue but was not successful so ended up with a hotfix. I believe one of the `View` parent components should force it to rerender. Hope this can be fixed later.