### PR TITLE
DGJ-22 Fixed cache permission issue when rendering PDF

### DIFF
--- a/forms-flow-bpm/Dockerfile.prod
+++ b/forms-flow-bpm/Dockerfile.prod
@@ -54,12 +54,14 @@ EXPOSE 8080
 RUN test ! -d /app && mkdir /app || :
 # Add spring boot application
 RUN mkdir -p /app
+RUN mkdir -p /.cache
 COPY --from=ubuntu-jdk /tmp/target/forms-flow-bpm*.jar ./app
 RUN chmod a+rwx -R /app
+RUN chmod a+rwx -R /.cache
 
 WORKDIR /app
 VOLUME /tmp
 
-RUN java -cp /app/forms-flow-bpm.jar -Dloader.main=com.microsoft.playwright.CLI org.springframework.boot.loader.PropertiesLauncher install-deps
+RUN java -cp /app/forms-flow-bpm.jar -Dloader.main=com.microsoft.playwright.CLI org.springframework.boot.loader.PropertiesLauncher install-deps chromium
 
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app/forms-flow-bpm.jar"]

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -67,6 +67,6 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
     }
 
     public String getEndpointUrl(String endpoint) {
-        return odsUrl + "/" + endpoint;
+        return odsUrl + "#" + endpoint;
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue when rendering a PDF in dev using Playwright: it fails with a permission denied error in the /.cache folder.
It also fixes an issue where the ODS endpoint to send submissions to is constructed wrong 
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Updated Dockerfile.prod to create a /.cache folder + update permissions accordingly
- Updated ODS url to use `#` instead of `/` as a separator for the endpoint part
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->