### PR TITLE
DGJ-135 Fixed BPM ODS auth issue

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/ODSAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/ODSAccessHandler.java
@@ -26,7 +26,7 @@ public class ODSAccessHandler implements IAccessHandler {
     private final Logger LOGGER = LoggerFactory.getLogger(ODSAccessHandler.class);
 
     @Autowired
-    private WebClient webClient;
+    private WebClient unauthenticatedWebClient;
 
     @Value("${formsflow.ai.ods.security.token}")
     private String odsAuthHeader;
@@ -35,7 +35,7 @@ public class ODSAccessHandler implements IAccessHandler {
 
         payload = (payload == null) ? new JsonObject().toString() : payload;
 
-        Mono<ResponseEntity<String>> entityMono = webClient.method(method).uri(url)
+        Mono<ResponseEntity<String>> entityMono = unauthenticatedWebClient.method(method).uri(url)
                 .header("Authorization", odsAuthHeader)
                 .accept(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -67,6 +67,6 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
     }
 
     public String getEndpointUrl(String endpoint) {
-        return odsUrl + "#" + endpoint;
+        return odsUrl + "/" + endpoint;
     }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
@@ -181,9 +181,9 @@ public class FormSubmissionService {
                             .map(n -> n.get("originalName").asText())
                             .collect(Collectors.joining(", "));
                     fieldValues.put(entry.getKey(), fileNames);
-                } else if(!withFileInfo && entry.getValue() != null && !entry.getValue().toString().startsWith("data:image/png;base64,")) {
+                } else if(!withFileInfo && entry.getValue() != null && entry.getValue().asText().startsWith("data:image/png")) {
                     // Replace any inline files with the type of image (signatures)
-                    fieldValues.put(entry.getKey(), "image/png;base64");
+                    fieldValues.put(entry.getKey(), "data:image/png");
                 } else if(StringUtils.endsWithIgnoreCase(entry.getKey(),"_file")) {
                     List<String> fileNames = new ArrayList();
                     if (entry.getValue().isArray()) {


### PR DESCRIPTION
## Summary
Fixed an auth issue when sending data to the ODS. Also reverted the previous url change as it was correct before.
Apparently there's two `WebClient` beans made available for use, one that will add a `Authorization` header and one for use for any external services where you want to specify the `Authorization` header.

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Changed `webClient` to `unauthenticatedWebClient ` to fix ODS authentication issue
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->