### PR TITLE
DGJ-135 Delay rendering of form for PDF

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/TaskAssignmentListener.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/TaskAssignmentListener.java
@@ -3,8 +3,10 @@ package org.camunda.bpm.extension.hooks.listeners;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Page.WaitForSelectorOptions;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.Margin;
+import com.microsoft.playwright.options.WaitForSelectorState;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
@@ -189,7 +191,7 @@ public class TaskAssignmentListener extends BaseListener implements TaskListener
             Page page = browser.newPage();
 
             page.navigate(file.toPath().toUri().toURL().toString());
-            page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            page.waitForSelector("#formio-form-rendered", new WaitForSelectorOptions().setState(WaitForSelectorState.ATTACHED));
 
             page.pdf(new Page.PdfOptions().setPath(Paths.get("form.pdf")).setMargin(new Margin().setRight("40px").setLeft("40px").setTop("40px").setBottom("40px")));
         }

--- a/forms-flow-bpm/src/main/resources/templates/form.html
+++ b/forms-flow-bpm/src/main/resources/templates/form.html
@@ -9,16 +9,22 @@
 <div id="formio"></div>
 <script type='text/javascript' src="https://unpkg.com/formiojs@4.13.1/dist/formio.full.min.js"></script>
 <script type='text/javascript'>
-    Formio.icons = 'fontawesome'
+    Formio.icons = 'fontawesome';
     Formio.createForm(
         document.getElementById('formio'),
         ${formFields}).then(function (form) {
             form.submission = {
                 "data": ${formValues}
             };
+
+            setTimeout(function() {
+                var successDiv = document.createElement('div');
+
+                successDiv.setAttribute("id", 'formio-form-rendered');
+                document.body.appendChild(successDiv);
+            }, 0);
         }
-    )
-    ;
+    );
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Add a `setTimeout` to wait for the page to complete rendering before triggering PDF generation. Now the generation waits for a `#formio-form-rendered` element to be inserted into the page before starting.
Should (hopefully) fix an issue in dev where the PDF is sometimes blank.

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Insert an empty `#formio-form-rendered` div after setting the form submission
- Wait for `#formio-form-rendered` before rendering
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->