### PR TITLE
DGJ-72 Split email sending for telework form into separate tasks

### DIFF
--- a/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
+++ b/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0993co4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0993co4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <bpmn:process id="teleworkform" name="Telework Form" isExecutable="true" camunda:versionTag="4">
     <bpmn:startEvent id="StartEvent_1" name="Submitted Form">
       <bpmn:outgoing>SequenceFlow_0ociprs</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="reviewer" name="Supervisor Reviews Submission" camunda:asyncAfter="true" camunda:assignee="${managerEmail}" camunda:candidateUsers="${managerEmail}">
+    <bpmn:userTask id="reviewer" name="Supervisor Reviews Submission" camunda:assignee="${managerEmail}" camunda:candidateUsers="${managerEmail}">
       <bpmn:extensionElements>
         <camunda:formData>
           <camunda:formField id="action" label="Action" type="string" />
         </camunda:formData>
         <camunda:taskListener event="complete">
           <camunda:script scriptFormat="javascript">task.execution.setVariable('applicationStatus', task.execution.getVariable('action'));
-task.execution.setVariable('deleteReason', "completed");
+task.execution.setVariable('deleteReason', 'completed');
+task.execution.setVariable('managerSignatureTimestamp', new Date().toISOString());
 
-task.execution.setVariable('managerSignatureTimestamp', new Date());</camunda:script>
+</camunda:script>
         </camunda:taskListener>
         <camunda:taskListener class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener" event="create" id="manager_task_created">
           <camunda:field name="body">
@@ -47,37 +48,6 @@ Thank you</camunda:expression>
           </camunda:field>
           <camunda:field name="permissions">
             <camunda:expression>["read", "write"]</camunda:expression>
-          </camunda:field>
-        </camunda:taskListener>
-        <camunda:taskListener class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener" event="complete" id="send_confirmation_manager">
-          <camunda:field name="body">
-            <camunda:expression>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:expression>
-          </camunda:field>
-          <camunda:field name="subject">
-            <camunda:expression>PDF copy of form</camunda:expression>
-          </camunda:field>
-          <camunda:field name="recipientEmails">
-            <camunda:expression>${managerEmail}</camunda:expression>
-          </camunda:field>
-          <camunda:field name="attachSubmission">
-            <camunda:string>true</camunda:string>
-          </camunda:field>
-          <camunda:field name="attachments">
-            <camunda:string>file</camunda:string>
-          </camunda:field>
-        </camunda:taskListener>
-        <camunda:taskListener class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener" event="complete" id="send_confirmation_submitter">
-          <camunda:field name="body">
-            <camunda:string>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:string>
-          </camunda:field>
-          <camunda:field name="subject">
-            <camunda:string>PDF copy of form</camunda:string>
-          </camunda:field>
-          <camunda:field name="recipientEmails">
-            <camunda:expression>${email}</camunda:expression>
-          </camunda:field>
-          <camunda:field name="attachSubmission">
-            <camunda:string>true</camunda:string>
           </camunda:field>
         </camunda:taskListener>
       </bpmn:extensionElements>
@@ -123,7 +93,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
       <bpmn:incoming>SequenceFlow_0pc6hcp</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_00bn1p7</bpmn:outgoing>
     </bpmn:task>
-    <bpmn:sequenceFlow id="SequenceFlow_00bn1p7" sourceRef="Task_1hko8r7" targetRef="send_to_ods" />
+    <bpmn:sequenceFlow id="SequenceFlow_00bn1p7" sourceRef="Task_1hko8r7" targetRef="Gateway_1cbqsut" />
     <bpmn:sequenceFlow id="SequenceFlow_1x38yu4" name="approve" sourceRef="ExclusiveGateway_0l1c65j" targetRef="Task_1hko8r7">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${action == 'Approved'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -150,98 +120,199 @@ execution.setVariable('applicationStatus','New');</camunda:script>
       </bpmn:extensionElements>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_01iapsa" sourceRef="send_to_ods" targetRef="EndEvent_03cla68" />
-    <bpmn:serviceTask id="send_to_ods" name="Send Submission to ODS" camunda:class="org.camunda.bpm.extension.hooks.listeners.SendSubmissionToODSDelegate">
+    <bpmn:serviceTask id="send_to_ods" name="Send Submission to ODS" camunda:asyncBefore="true" camunda:class="org.camunda.bpm.extension.hooks.listeners.SendSubmissionToODSDelegate">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="endpoint">Datamart_Telework_app_telework_info</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_00bn1p7</bpmn:incoming>
+      <bpmn:incoming>Flow_0drjush</bpmn:incoming>
+      <bpmn:incoming>Flow_0sjq2d0</bpmn:incoming>
       <bpmn:outgoing>Flow_01iapsa</bpmn:outgoing>
       <bpmn:dataOutputAssociation id="DataOutputAssociation_0n0lg8r">
         <bpmn:targetRef>DataStoreReference_0iew98f</bpmn:targetRef>
       </bpmn:dataOutputAssociation>
     </bpmn:serviceTask>
     <bpmn:dataStoreReference id="DataStoreReference_0iew98f" name="ODS" />
+    <bpmn:sequenceFlow id="Flow_0drjush" sourceRef="Activity_0udx9dh" targetRef="send_to_ods" />
+    <bpmn:serviceTask id="Activity_0cnvjyo" name="Send Submission PDF to Submitter" camunda:asyncBefore="true" camunda:class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener">
+      <bpmn:extensionElements>
+        <camunda:field name="attachSubmission">
+          <camunda:string>true</camunda:string>
+        </camunda:field>
+        <camunda:field name="recipientEmails">
+          <camunda:expression>${email}</camunda:expression>
+        </camunda:field>
+        <camunda:field name="body">
+          <camunda:expression>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:expression>
+        </camunda:field>
+        <camunda:field name="subject">
+          <camunda:string>PDF copy of ${formName}</camunda:string>
+        </camunda:field>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0g6bjba</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sjq2d0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_0udx9dh" name="Send Submission PDF to Manager" camunda:asyncBefore="true" camunda:class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener">
+      <bpmn:extensionElements>
+        <camunda:field name="attachSubmission">
+          <camunda:string>true</camunda:string>
+        </camunda:field>
+        <camunda:field name="attachments">
+          <camunda:string>file</camunda:string>
+        </camunda:field>
+        <camunda:field name="body">
+          <camunda:expression>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:expression>
+        </camunda:field>
+        <camunda:field name="subject">
+          <camunda:string>PDF copy of form</camunda:string>
+        </camunda:field>
+        <camunda:field name="recipientEmails">
+          <camunda:expression>${managerEmail}</camunda:expression>
+        </camunda:field>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1qpbb9j</bpmn:incoming>
+      <bpmn:outgoing>Flow_0drjush</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="Gateway_1cbqsut">
+      <bpmn:incoming>SequenceFlow_00bn1p7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0g6bjba</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1qpbb9j</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0g6bjba" sourceRef="Gateway_1cbqsut" targetRef="Activity_0cnvjyo" />
+    <bpmn:sequenceFlow id="Flow_1qpbb9j" sourceRef="Gateway_1cbqsut" targetRef="Activity_0udx9dh" />
+    <bpmn:sequenceFlow id="Flow_0sjq2d0" sourceRef="Activity_0cnvjyo" targetRef="send_to_ods" />
+    <bpmn:textAnnotation id="TextAnnotation_1vplb42">
+      <bpmn:text>Attached Uploaded ADM Approval Record if required</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1tytyjh" sourceRef="Activity_0udx9dh" targetRef="TextAnnotation_1vplb42" />
+    <bpmn:textAnnotation id="TextAnnotation_10vy6xw">
+      <bpmn:text>Sends Email to Manager when task is created</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_066hahd" sourceRef="reviewer" targetRef="TextAnnotation_10vy6xw" />
   </bpmn:process>
   <bpmn:message id="Message_1ihrno3" name="Message_Email" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="teleworkform">
+      <bpmndi:BPMNEdge id="Flow_0sjq2d0_di" bpmnElement="Flow_0sjq2d0">
+        <di:waypoint x="920" y="190" />
+        <di:waypoint x="950" y="190" />
+        <di:waypoint x="950" y="240" />
+        <di:waypoint x="980" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qpbb9j_di" bpmnElement="Flow_1qpbb9j">
+        <di:waypoint x="790" y="285" />
+        <di:waypoint x="790" y="330" />
+        <di:waypoint x="820" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g6bjba_di" bpmnElement="Flow_0g6bjba">
+        <di:waypoint x="790" y="235" />
+        <di:waypoint x="790" y="190" />
+        <di:waypoint x="820" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0drjush_di" bpmnElement="Flow_0drjush">
+        <di:waypoint x="920" y="330" />
+        <di:waypoint x="950" y="330" />
+        <di:waypoint x="950" y="280" />
+        <di:waypoint x="980" y="280" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01iapsa_di" bpmnElement="Flow_01iapsa">
-        <di:waypoint x="1050" y="270" />
-        <di:waypoint x="1122" y="270" />
+        <di:waypoint x="1080" y="260" />
+        <di:waypoint x="1172" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eqfxon_di" bpmnElement="Flow_0eqfxon">
-        <di:waypoint x="410" y="160" />
-        <di:waypoint x="490" y="160" />
+        <di:waypoint x="340" y="260" />
+        <di:waypoint x="380" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0pc6hcp_di" bpmnElement="SequenceFlow_0pc6hcp">
-        <di:waypoint x="705" y="270" />
-        <di:waypoint x="758" y="270" />
-        <di:waypoint x="758" y="300" />
-        <di:waypoint x="810" y="300" />
+        <di:waypoint x="565" y="260" />
+        <di:waypoint x="593" y="260" />
+        <di:waypoint x="593" y="290" />
+        <di:waypoint x="620" y="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="730" y="283" width="27" height="14" />
+          <dc:Bounds x="579" y="303" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1x38yu4_di" bpmnElement="SequenceFlow_1x38yu4">
-        <di:waypoint x="705" y="270" />
-        <di:waypoint x="758" y="270" />
-        <di:waypoint x="758" y="250" />
-        <di:waypoint x="810" y="250" />
+        <di:waypoint x="565" y="260" />
+        <di:waypoint x="593" y="260" />
+        <di:waypoint x="593" y="240" />
+        <di:waypoint x="620" y="240" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="712" y="252" width="40" height="14" />
+          <dc:Bounds x="573" y="213" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_00bn1p7_di" bpmnElement="SequenceFlow_00bn1p7">
-        <di:waypoint x="910" y="270" />
-        <di:waypoint x="950" y="270" />
+        <di:waypoint x="720" y="260" />
+        <di:waypoint x="765" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jg4sg3_di" bpmnElement="SequenceFlow_0jg4sg3">
-        <di:waypoint x="590" y="160" />
-        <di:waypoint x="680" y="160" />
-        <di:waypoint x="680" y="245" />
+        <di:waypoint x="480" y="260" />
+        <di:waypoint x="515" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ociprs_di" bpmnElement="SequenceFlow_0ociprs">
-        <di:waypoint x="208" y="160" />
-        <di:waypoint x="310" y="160" />
+        <di:waypoint x="208" y="260" />
+        <di:waypoint x="240" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="172" y="142" width="36" height="36" />
+        <dc:Bounds x="172" y="242" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="151" y="185" width="79" height="14" />
+          <dc:Bounds x="151" y="285" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0l4y66o_di" bpmnElement="reviewer">
-        <dc:Bounds x="490" y="120" width="100" height="80" />
+        <dc:Bounds x="380" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_03cla68_di" bpmnElement="EndEvent_03cla68">
-        <dc:Bounds x="1122" y="252" width="36" height="36" />
+        <dc:Bounds x="1172" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0l1c65j_di" bpmnElement="ExclusiveGateway_0l1c65j" isMarkerVisible="true">
-        <dc:Bounds x="655" y="245" width="50" height="50" />
+        <dc:Bounds x="515" y="235" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="645" y="305" width="70" height="14" />
+          <dc:Bounds x="505" y="285" width="70" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0fde0ul_di" bpmnElement="Task_1hko8r7">
-        <dc:Bounds x="810" y="230" width="100" height="80" />
+        <dc:Bounds x="620" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1i967b8_di" bpmnElement="Activity_0kai049">
-        <dc:Bounds x="310" y="120" width="100" height="80" />
+        <dc:Bounds x="240" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0qjfbs1_di" bpmnElement="send_to_ods">
-        <dc:Bounds x="950" y="230" width="100" height="80" />
+        <dc:Bounds x="980" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataStoreReference_0iew98f_di" bpmnElement="DataStoreReference_0iew98f">
-        <dc:Bounds x="975" y="85" width="50" height="50" />
+        <dc:Bounds x="1005" y="105" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="988" y="113" width="24" height="14" />
+          <dc:Bounds x="1018" y="81" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pmly6k_di" bpmnElement="Activity_0cnvjyo">
+        <dc:Bounds x="820" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1rq77c4_di" bpmnElement="Activity_0udx9dh">
+        <dc:Bounds x="820" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wuscnx_di" bpmnElement="Gateway_1cbqsut">
+        <dc:Bounds x="765" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1vplb42_di" bpmnElement="TextAnnotation_1vplb42">
+        <dc:Bounds x="820" y="390" width="130" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_10vy6xl_di" bpmnElement="TextAnnotation_10vy6xw">
+        <dc:Bounds x="380" y="140" width="100" height="54" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="DataOutputAssociation_0n0lg8r_di" bpmnElement="DataOutputAssociation_0n0lg8r">
-        <di:waypoint x="1000" y="230" />
-        <di:waypoint x="1000" y="135" />
+        <di:waypoint x="1030" y="220" />
+        <di:waypoint x="1030" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1tytyjh_di" bpmnElement="Association_1tytyjh">
+        <di:waypoint x="870" y="370" />
+        <di:waypoint x="870" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_066hahd_di" bpmnElement="Association_066hahd">
+        <di:waypoint x="430" y="220" />
+        <di:waypoint x="430" y="194" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
## Summary
- Fixed setting of the `managerSignatureTimestamp` variable - which I believe might have caused some of the email sending issues in dev 👀 
- Moved email sending for telework form into separate tasks and added transaction boundaries to make issues show up in Camunda + not roll back any tasks that already completed on failure. Should prevent e.g. double sending of emails if you retry a failed task

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
-  Modified the TaskAssignmentListener to allow usage through service tasks
- Updated Telework Form bpmn to fix email sending issues
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

![image](https://user-images.githubusercontent.com/66635118/160200736-0f61c282-7bfe-41e3-b267-0a4bfe98f7dc.png)
![image](https://user-images.githubusercontent.com/66635118/160200764-8f44e88a-28c1-4535-9b6a-895d2027e006.png)
![image](https://user-images.githubusercontent.com/66635118/160200773-0230f6e0-fb8b-4245-b712-b2964f692422.png)


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->