### PR TITLE
DGJ-158 Allow docx + msg files as default for file upload

### DIFF
--- a/forms-flow-web/src/formComponents/FileUpload/index.js
+++ b/forms-flow-web/src/formComponents/FileUpload/index.js
@@ -8,7 +8,7 @@ const Field = Components.components.field;
  * Custom Form.io file upload component.
  * This is based on the default file upload component, but provides the following default values:
  * - Private Downloads
- * - File Pattern: image/*,application/pdf,message/rfc822
+ * - File Pattern: image/*,application/pdf,message/rfc822,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-outlook
  * - Max file size: 15MB
  * - Storage provider: digital-journeys
  */
@@ -22,10 +22,10 @@ export default class DGJFileUpload extends FileComponent{
       image: false,
       privateDownload: true,
       imageSize: '200',
-      filePattern: 'image/*,application/pdf,message/rfc822',
+      filePattern: 'image/*,application/pdf,message/rfc822,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-outlook',
       fileMinSize: '0KB',
       fileMaxSize: '15MB',
-      description: 'Supported file types: .eml, .pdf, common image formats',
+      description: 'Supported file types: .eml, .msg, .docx, .pdf, common image formats',
       uploadOnly: false,
       storage: 'digital-journeys',
     }, ...extend);


### PR DESCRIPTION
## Summary
Added docx + msg to allow list as default for file upload component

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
-Added docx + msg to allow list as default for file upload component
![image](https://user-images.githubusercontent.com/66635118/160202144-0e56e329-c0f5-44d2-9d2f-e3ebbcb9a697.png)


## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/66635118/160202153-c5974a65-7d56-4901-91d2-c3d8d3e3c378.png)

<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->