### PR TITLE
DGJ-161 Fixed handling of expired tokens when retrieving files for email

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FileAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FileAccessHandler.java
@@ -1,6 +1,7 @@
 package org.camunda.bpm.extension.commons.connector.support;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang.StringUtils;
 import org.camunda.bpm.extension.hooks.exceptions.FormioServiceException;
 import org.camunda.bpm.extension.commons.connector.support.FormAccessHandler;
 
@@ -32,6 +33,7 @@ import java.net.URLEncoder;
 public class FileAccessHandler extends FormAccessHandler implements IAccessHandler {
 
     private final Logger logger = LoggerFactory.getLogger(FileAccessHandler.class.getName());
+    static final int TOKEN_EXPIRY_CODE = 401;
 
     @Autowired
     private NamedParameterJdbcTemplate bpmJdbcTemplate;
@@ -60,4 +62,8 @@ public class FileAccessHandler extends FormAccessHandler implements IAccessHandl
                 .block();
     }
 
+    @Override
+    protected Integer getExpiryCode() {
+        return TOKEN_EXPIRY_CODE;
+    }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FormAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FormAccessHandler.java
@@ -1,0 +1,131 @@
+package org.camunda.bpm.extension.commons.connector.support;
+
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.camunda.bpm.engine.ProcessEngines;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.extension.hooks.exceptions.FormioServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * This class serves as gateway for all formio interactions.
+ *
+ * @author sumathi.thirumani@aot-technologies.com
+ */
+@Service("formAccessHandler")
+public class FormAccessHandler extends FormTokenAccessHandler implements IAccessHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(FormAccessHandler.class.getName());
+
+    static final String TOKEN_NAME = "formio_access_token";
+    static final String TOKEN_PROCESS_NAME = "formio-access-token";
+    static final int TOKEN_EXPIRY_CODE = 404;
+
+    @Autowired
+    private NamedParameterJdbcTemplate bpmJdbcTemplate;
+
+    @Autowired
+    private WebClient unauthenticatedWebClient;
+
+
+    public ResponseEntity<String> exchange(String url, HttpMethod method, String payload) {
+        String accessToken = getToken();
+        if(StringUtils.isBlank(accessToken)) {
+            logger.info("Access token is blank. Cannot invoke service:{}", url);
+            return null;
+        }
+        ResponseEntity<String> response = exchange(url,method,payload,accessToken);
+        if(response.getStatusCodeValue() == getExpiryCode()) {
+            exchange(url,method,payload,getAccessToken());
+        }
+        logger.info("Response code for service invocation: {}" , response.getStatusCode());
+        return response;
+    }
+
+    public ResponseEntity<String> exchange(String url, HttpMethod method, String payload, String accessToken) {
+
+        payload = (payload == null) ? new JsonObject().toString() : payload;
+
+        if(HttpMethod.PATCH.name().equals(method.name())) {
+            logger.info("payload="+payload);
+            Mono<ResponseEntity<String>> entityMono = unauthenticatedWebClient.patch()
+                    .uri(getDecoratedServerUrl(url))
+                    .bodyValue(payload)
+                    .header("x-jwt-token", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .retrieve()
+                    .onStatus(HttpStatus::is4xxClientError,
+                            response -> Mono.error(new FormioServiceException(response.toString())))
+                    .toEntity(String.class);
+
+            ResponseEntity<String> response = entityMono.block();
+            if(response !=null && "Token Expired".equalsIgnoreCase(response.getBody())) {
+                return new ResponseEntity<>(response.getBody(), HttpStatus.valueOf(TOKEN_EXPIRY_CODE));
+            }
+            return response;
+        } else {
+            return unauthenticatedWebClient.method(method)
+                    .uri(getDecoratedServerUrl(url))
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .header("x-jwt-token", accessToken)
+                    .body(Mono.just(payload), String.class)
+                    .retrieve()
+                    .onStatus(HttpStatus::is4xxClientError,
+                            response -> Mono.error(new FormioServiceException(response.toString())))
+                    .toEntity(String.class)
+                    .block();
+        }
+    }
+
+    private String getDecoratedServerUrl(String url) {
+        if(StringUtils.contains(url,"/form/")) {
+            return getIntegrationCredentialProperties().getProperty("formio.url") + "/form/" + StringUtils.substringAfter(url, "/form/");
+        }
+        return getIntegrationCredentialProperties().getProperty("formio.url") +"/"+ StringUtils.substringAfterLast(url, "/");
+    }
+
+    private String getToken() {
+        ProcessDefinition processDefinition = ProcessEngines.getDefaultProcessEngine().getRepositoryService().createProcessDefinitionQuery()
+                .latestVersion()
+                .processDefinitionKey(TOKEN_PROCESS_NAME)
+                .singleResult();
+        String accessToken = processDefinition != null ? getTokenFromDBStore(processDefinition.getId()) : null;
+        if(StringUtils.isBlank(accessToken)) {
+            logger.info("Unable to extract token from variable context. Generating new JWT token.");
+            return accessToken != null ? accessToken : getAccessToken();
+        }
+        return accessToken;
+    }
+
+    private String getTokenFromDBStore(String processDefinitionId) {
+        String query = "select arv.text_ from act_ru_variable arv, act_ru_job rjb " +
+                "where arv.proc_def_id_ = rjb.process_def_id_ and arv.proc_inst_id_  " +
+                "= rjb.process_instance_id_ and rjb.process_def_key_=:tokenProcessName " +
+                "and rjb.type_='timer' and arv.name_ = :tokenName " +
+                "and rjb.process_def_id_ =:processDefinitionId order by rjb.create_time_ desc LIMIT 1";
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue("tokenProcessName", TOKEN_PROCESS_NAME);
+        parameters.addValue("tokenName", TOKEN_NAME);
+        parameters.addValue("processDefinitionId", processDefinitionId);
+        return bpmJdbcTemplate.queryForObject(query,parameters, String.class);
+    }
+
+    protected Integer getExpiryCode() {
+        return TOKEN_EXPIRY_CODE;
+    }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FormAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FormAccessHandler.java
@@ -60,7 +60,6 @@ public class FormAccessHandler extends FormTokenAccessHandler implements IAccess
         payload = (payload == null) ? new JsonObject().toString() : payload;
 
         if(HttpMethod.PATCH.name().equals(method.name())) {
-            logger.info("payload="+payload);
             Mono<ResponseEntity<String>> entityMono = unauthenticatedWebClient.patch()
                     .uri(getDecoratedServerUrl(url))
                     .bodyValue(payload)

--- a/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
+++ b/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
@@ -147,7 +147,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
           <camunda:expression>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:expression>
         </camunda:field>
         <camunda:field name="subject">
-          <camunda:string>PDF copy of ${formName}</camunda:string>
+          <camunda:expression>PDF Copy of ${formName}</camunda:expression>
         </camunda:field>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0g6bjba</bpmn:incoming>
@@ -165,7 +165,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
           <camunda:expression>This is a pdf copy of the form submitted by ${submitterName} for your records.</camunda:expression>
         </camunda:field>
         <camunda:field name="subject">
-          <camunda:string>PDF copy of form</camunda:string>
+          <camunda:expression>PDF Copy of ${formName}</camunda:expression>
         </camunda:field>
         <camunda:field name="recipientEmails">
           <camunda:expression>${managerEmail}</camunda:expression>


### PR DESCRIPTION
## Summary
Fixed handling of expired tokens when retrieving files for email. After a while, email sending seems to be failing with an error indicating that the access token used to retrieve it from Camunda has expired. The cause of this can be found in the FormAccessHandler / FileAccessHandler. The `FormAccessHandler` retries a request if a 404 is returned (by Form.io) as in that service this could indicate an expired token. For the file service however, a 401 is returned, so the request would not be retried with a refreshed token.



<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Updated FileAccessHandler to retry the request with a refreshed access token if it fails with a 401
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->