### PR TITLE
DGJ-161 Generate new auth token when fetching file for emails

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FileAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/FileAccessHandler.java
@@ -41,8 +41,10 @@ public class FileAccessHandler extends FormAccessHandler implements IAccessHandl
     @Autowired
     private WebClient unauthenticatedWebClient;
 
-    @Value("${formsflow.ai.formio.url}")
-    private String formioUrl;
+    @Override
+    public ResponseEntity<String> exchange(String url, HttpMethod method, String payload) {
+        return exchange(url, method, payload, getAccessToken());
+    }
 
     @Override
     public ResponseEntity<String> exchange(String url, HttpMethod method, String payload, String accessToken) {


### PR DESCRIPTION
## Summary
Attempt #10 to fix the 401 error that sometimes pops up when attaching a file to an email. I've not been able to reproduce this locally, hence the many tries 😓 

From the looks of it, the 401 now sometimes happens in the signed url that is generated by formio and returned by the file service. The created token embedded in the url is sometimes expired which in the end causes the 401. *I believe* the expiry time is based on the issue time of the auth token that's used to request the file, so this PR includes a fix that makes sure we generate a new token to request the file so Formio in the end will not generate a token that is expired.
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Modified `FileAccessHandler` to always use a new token when requesting a file
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->