### PR TITLE
Fix/dgj 169 auto populate data

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/employeeDataService.py
+++ b/forms-flow-api/src/formsflow_api/services/employeeDataService.py
@@ -24,5 +24,5 @@ class EmployeeDataService:
 
       if employee_data_res and employee_data_res["value"] and len(employee_data_res["value"]) > 0:
         emp_data = EmployeeData(employee_data_res["value"][0])
-        return emp_data.__dict__, HTTPStatus
+        return emp_data.__dict__
       return {"message": "No user data found"}, HTTPStatus.NOT_FOUND

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -27,6 +27,7 @@ import { CUSTOM_EVENT_TYPE } from "../../ServiceFlow/constants/customEventTypes"
 import { toast } from "react-toastify";
 
 const View = React.memo((props) => {
+  console.log("View renders...", props);
   const isFormSubmissionLoading = useSelector(
     (state) => state.formDelete.isFormSubmissionLoading
   );
@@ -42,6 +43,7 @@ const View = React.memo((props) => {
     getEmployeeData,
     employeeData,
   } = props;
+  console.log(form);
   const dispatch = useDispatch();
 
   const [isInitialDataSet, setIsInitialDataSet] = useState(false)
@@ -112,7 +114,10 @@ const View = React.memo((props) => {
 
     const defaultValuesObject = defaultValuesArray?.reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
-    setIsInitialDataSet(true);
+    console.log("defaultValuesObject", defaultValuesObject);
+    setTimeout(() => {
+      setIsInitialDataSet(true);
+    }, 4000);
 
     return { data: defaultValuesObject };
   };

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -46,8 +46,6 @@ const View = React.memo((props) => {
   console.log(form);
   const dispatch = useDispatch();
 
-  const [isInitialDataSet, setIsInitialDataSet] = useState(false)
-
   useEffect(() => {
     if (!isAuthenticated) {
       getForm();
@@ -68,7 +66,7 @@ const View = React.memo((props) => {
   const getDefaultValues = (data) => {
     if (
       Object.keys(data)?.length === 0 ||
-      form.components?.length === 0 || isInitialDataSet) {
+      form.components?.length === 0) {
       return;
     }
 
@@ -113,11 +111,6 @@ const View = React.memo((props) => {
     });
 
     const defaultValuesObject = defaultValuesArray?.reduce((acc, curr) => ({ ...acc, ...curr }), {});
-
-    console.log("defaultValuesObject", defaultValuesObject);
-    // setTimeout(() => {
-    //   setIsInitialDataSet(true);
-    // }, 4000);
 
     return { data: defaultValuesObject };
   };

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -27,7 +27,6 @@ import { CUSTOM_EVENT_TYPE } from "../../ServiceFlow/constants/customEventTypes"
 import { toast } from "react-toastify";
 
 const View = React.memo((props) => {
-  console.log("View renders...", props);
   const isFormSubmissionLoading = useSelector(
     (state) => state.formDelete.isFormSubmissionLoading
   );
@@ -43,7 +42,6 @@ const View = React.memo((props) => {
     getEmployeeData,
     employeeData,
   } = props;
-  console.log(form);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -67,8 +67,8 @@ const View = React.memo((props) => {
 
   const getDefaultValues = (data) => {
     if (
-      Object.keys(data).length === 0 ||
-      form.components.length === 0 || isInitialDataSet) {
+      Object.keys(data)?.length === 0 ||
+      form.components?.length === 0 || isInitialDataSet) {
       return;
     }
 
@@ -115,9 +115,9 @@ const View = React.memo((props) => {
     const defaultValuesObject = defaultValuesArray?.reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
     console.log("defaultValuesObject", defaultValuesObject);
-    setTimeout(() => {
-      setIsInitialDataSet(true);
-    }, 4000);
+    // setTimeout(() => {
+    //   setIsInitialDataSet(true);
+    // }, 4000);
 
     return { data: defaultValuesObject };
   };

--- a/forms-flow-web/src/services/UserService.js
+++ b/forms-flow-web/src/services/UserService.js
@@ -73,14 +73,17 @@ const initKeycloak = (store, ...rest) => {
 let refreshInterval;
 const refreshToken = (store) => {
   refreshInterval = setInterval(() => {
-    KeycloakData && KeycloakData.updateToken(-1).then((refreshed)=> {
-      if (refreshed) {
-        localStorage.setItem('authToken', KeycloakData.token);
-      }
-    }).catch( (error)=> {
-      console.log(error);
-      userLogout();
-    });
+    KeycloakData &&
+      KeycloakData.updateToken(5)
+        .then((refreshed) => {
+          if (refreshed) {
+            localStorage.setItem("authToken", KeycloakData.token);
+          }
+        })
+        .catch((error) => {
+          console.log(error);
+          userLogout();
+        });
   }, 5000);
 }
 

--- a/forms-flow-web/src/services/UserService.js
+++ b/forms-flow-web/src/services/UserService.js
@@ -75,7 +75,7 @@ const refreshToken = (store) => {
   refreshInterval = setInterval(() => {
     KeycloakData && KeycloakData.updateToken(-1).then((refreshed)=> {
       if (refreshed) {
-        store.dispatch(setUserToken(KeycloakData.token));
+        localStorage.setItem('authToken', KeycloakData.token);
       }
     }).catch( (error)=> {
       console.log(error);

--- a/forms-flow-web/src/services/UserService.js
+++ b/forms-flow-web/src/services/UserService.js
@@ -1,0 +1,157 @@
+ /* istanbul ignore file */
+import {
+  ROLES,
+  USER_RESOURCE_FORM_ID,
+  Keycloak_Client,
+  ANONYMOUS_USER,
+  ANONYMOUS_ID,
+  FORMIO_JWT_SECRET
+} from "../constants/constants";
+import {
+  setUserRole,
+  setUserToken,
+  setUserDetails,
+} from "../actions/bpmActions";
+import {BPM_BASE_URL} from "../apiManager/endpoints/config";
+import {AppConfig} from '../config';
+import {WEB_BASE_URL , WEB_BASE_CUSTOM_URL} from "../apiManager/endpoints/config";
+
+import {_kc} from "../constants/tenantConstant";
+
+const jwt = require("jsonwebtoken");
+
+/**
+ * Initializes Keycloak instance and calls the provided callback function if successfully authenticated.
+ *
+ * @param onAuthenticatedCallback
+ */
+// const KeycloakData = new Keycloak(tenantDetail);
+
+
+const initKeycloak = (store, ...rest) => {
+  const done = rest.length ? rest[0] : () => {};
+  KeycloakData
+    .init({
+      onLoad: "check-sso",
+      promiseType: "native",
+      silentCheckSsoRedirectUri:
+        window.location.origin + "/silent-check-sso.html",
+      pkceMethod: "S256",
+      checkLoginIframe: false
+    })
+    .then((authenticated) => {
+      if (authenticated) {
+        if (KeycloakData.resourceAccess[Keycloak_Client]) {
+          const UserRoles = KeycloakData.resourceAccess[Keycloak_Client].roles;
+          store.dispatch(setUserRole(UserRoles));
+          store.dispatch(setUserToken(KeycloakData.token));
+          //Set Cammunda/Formio Base URL
+          setApiBaseUrlToLocalStorage();
+
+          let roles = [];
+          for (let i = 0; i < UserRoles.length; i++) {
+            const roleData = ROLES.find((x) => x.title === UserRoles[i]);
+            if (roleData) {
+              roles = roles.concat(roleData.id);
+            }
+          }
+          KeycloakData.loadUserInfo().then((res) => store.dispatch(setUserDetails(res)));
+          const email = KeycloakData.tokenParsed.email || "external";
+          authenticateFormio(email, roles);
+          // onAuthenticatedCallback();
+          done(null, KeycloakData);
+          refreshToken(store);
+        } else {
+          doLogout();
+        }
+      } else {
+        console.warn("not authenticated!");
+        doLogin();
+      }
+    });
+};
+let refreshInterval;
+const refreshToken = (store) => {
+  refreshInterval = setInterval(() => {
+    KeycloakData && KeycloakData.updateToken(-1).then((refreshed)=> {
+      if (refreshed) {
+        store.dispatch(setUserToken(KeycloakData.token));
+      }
+    }).catch( (error)=> {
+      console.log(error);
+      userLogout();
+    });
+  }, 5000);
+}
+
+
+/**
+ * Logout function
+ */
+const userLogout = () => {
+  localStorage.clear();
+  sessionStorage.clear();
+  clearInterval(refreshInterval);
+  doLogout();
+};
+
+const setApiBaseUrlToLocalStorage = ()=> {
+  localStorage.setItem("bpmApiUrl", BPM_BASE_URL);
+  localStorage.setItem("formioApiUrl", AppConfig.projectUrl);
+  localStorage.setItem("formsflow.ai.url",window.location.origin)
+  localStorage.setItem("formsflow.ai.api.url", WEB_BASE_URL);
+  localStorage.setItem("customApiUrl", WEB_BASE_CUSTOM_URL);
+}
+
+
+
+const getFormioToken = () => localStorage.getItem("formioToken");
+
+//const getUserEmail = () => KeycloakData.tokenParsed.email;
+
+/*const updateToken = (successCallback) => {
+  return KeycloakData.updateToken(5).then(successCallback).catch(doLogin);
+};*/
+
+const authenticateAnonymousUser = (store) => {
+  const user = ANONYMOUS_USER;
+  const roles = [ANONYMOUS_ID];
+  store.dispatch(setUserRole([user]));
+  authenticateFormio(user, roles);
+};
+
+const authenticateFormio = (user, roles) => {
+  
+  const FORMIO_TOKEN = jwt.sign(
+    {
+      external: true,
+      form: {
+        _id: USER_RESOURCE_FORM_ID, // form.io form Id of user resource
+      },
+      user: {
+        _id: user, // keep it like that
+        roles: roles,
+      },
+    },
+    FORMIO_JWT_SECRET
+  ); // TODO Move JWT secret key to COME From ENV
+  //TODO remove this token from local Storage on logout and try to move to redux store as well
+  localStorage.setItem("formioToken", FORMIO_TOKEN);
+};
+
+
+const KeycloakData= _kc;
+
+const doLogin = KeycloakData.login;
+const doLogout = KeycloakData.logout;
+const getToken = () => KeycloakData.token;
+
+const UserService ={
+  initKeycloak,
+  userLogout,
+  getToken,
+  getFormioToken,
+  authenticateAnonymousUser
+};
+
+export default UserService;


### PR DESCRIPTION
## Summary

This pr fixes the issue with auto-populate data from ODS reported in [this ticket](https://app.zenhub.com/workspaces/digital-journeys-61c10fe84c8bcb001491c5f5/issues/bcgov/digital-journeys/169)

## Changes
- A small fix to `employeeDataService.py`.
- The flag that previously was added to stop setting the default value s(from ODS) to the form was removed.
- Auth token refresh was no longer dispatches the token. This dispatch was the root cause that made the form refresh every 5 mins (depending on the auth token refresh interval value).

## Notes
Please read more about the auth token refresh issue [here ](https://github.com/bcgov/digital-journeys/pull/149)
We may want to watch in case any issue came up after stopping auth token dispatch.