### PR TITLE
DGJ-161 Fixed file attachment in client email

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/TaskAssignmentListener.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/TaskAssignmentListener.java
@@ -30,6 +30,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.task.AsyncTaskExecutor;
 
 import javax.activation.DataHandler;
@@ -52,6 +53,7 @@ import org.camunda.bpm.engine.delegate.JavaDelegate;
 import static java.lang.Thread.currentThread;
 
 @Named("TaskAssignmentListener")
+@Scope(value = "prototype")
 public class TaskAssignmentListener extends BaseListener implements TaskListener, ExecutionListener, JavaDelegate, IMessageEvent {
 
     protected MailConfiguration configuration;

--- a/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
+++ b/forms-flow-bpm/src/main/resources/processes/telework-form.bpmn
@@ -126,15 +126,13 @@ execution.setVariable('applicationStatus','New');</camunda:script>
           <camunda:inputParameter name="endpoint">Datamart_Telework_app_telework_info</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0drjush</bpmn:incoming>
-      <bpmn:incoming>Flow_0sjq2d0</bpmn:incoming>
+      <bpmn:incoming>Flow_107tioi</bpmn:incoming>
       <bpmn:outgoing>Flow_01iapsa</bpmn:outgoing>
       <bpmn:dataOutputAssociation id="DataOutputAssociation_0n0lg8r">
         <bpmn:targetRef>DataStoreReference_0iew98f</bpmn:targetRef>
       </bpmn:dataOutputAssociation>
     </bpmn:serviceTask>
     <bpmn:dataStoreReference id="DataStoreReference_0iew98f" name="ODS" />
-    <bpmn:sequenceFlow id="Flow_0drjush" sourceRef="Activity_0udx9dh" targetRef="send_to_ods" />
     <bpmn:serviceTask id="Activity_0cnvjyo" name="Send Submission PDF to Submitter" camunda:asyncBefore="true" camunda:class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener">
       <bpmn:extensionElements>
         <camunda:field name="attachSubmission">
@@ -151,7 +149,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
         </camunda:field>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0g6bjba</bpmn:incoming>
-      <bpmn:outgoing>Flow_0sjq2d0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0gikngm</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Activity_0udx9dh" name="Send Submission PDF to Manager" camunda:asyncBefore="true" camunda:class="org.camunda.bpm.extension.hooks.listeners.TaskAssignmentListener">
       <bpmn:extensionElements>
@@ -172,7 +170,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
         </camunda:field>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1qpbb9j</bpmn:incoming>
-      <bpmn:outgoing>Flow_0drjush</bpmn:outgoing>
+      <bpmn:outgoing>Flow_07pivsl</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:parallelGateway id="Gateway_1cbqsut">
       <bpmn:incoming>SequenceFlow_00bn1p7</bpmn:incoming>
@@ -181,7 +179,14 @@ execution.setVariable('applicationStatus','New');</camunda:script>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0g6bjba" sourceRef="Gateway_1cbqsut" targetRef="Activity_0cnvjyo" />
     <bpmn:sequenceFlow id="Flow_1qpbb9j" sourceRef="Gateway_1cbqsut" targetRef="Activity_0udx9dh" />
-    <bpmn:sequenceFlow id="Flow_0sjq2d0" sourceRef="Activity_0cnvjyo" targetRef="send_to_ods" />
+    <bpmn:sequenceFlow id="Flow_0gikngm" sourceRef="Activity_0cnvjyo" targetRef="Gateway_1gqg4sz" />
+    <bpmn:parallelGateway id="Gateway_1gqg4sz">
+      <bpmn:incoming>Flow_0gikngm</bpmn:incoming>
+      <bpmn:incoming>Flow_07pivsl</bpmn:incoming>
+      <bpmn:outgoing>Flow_107tioi</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_07pivsl" sourceRef="Activity_0udx9dh" targetRef="Gateway_1gqg4sz" />
+    <bpmn:sequenceFlow id="Flow_107tioi" sourceRef="Gateway_1gqg4sz" targetRef="send_to_ods" />
     <bpmn:textAnnotation id="TextAnnotation_1vplb42">
       <bpmn:text>Attached Uploaded ADM Approval Record if required</bpmn:text>
     </bpmn:textAnnotation>
@@ -194,12 +199,6 @@ execution.setVariable('applicationStatus','New');</camunda:script>
   <bpmn:message id="Message_1ihrno3" name="Message_Email" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="teleworkform">
-      <bpmndi:BPMNEdge id="Flow_0sjq2d0_di" bpmnElement="Flow_0sjq2d0">
-        <di:waypoint x="920" y="190" />
-        <di:waypoint x="950" y="190" />
-        <di:waypoint x="950" y="240" />
-        <di:waypoint x="980" y="240" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qpbb9j_di" bpmnElement="Flow_1qpbb9j">
         <di:waypoint x="790" y="285" />
         <di:waypoint x="790" y="330" />
@@ -210,15 +209,9 @@ execution.setVariable('applicationStatus','New');</camunda:script>
         <di:waypoint x="790" y="190" />
         <di:waypoint x="820" y="190" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0drjush_di" bpmnElement="Flow_0drjush">
-        <di:waypoint x="920" y="330" />
-        <di:waypoint x="950" y="330" />
-        <di:waypoint x="950" y="280" />
-        <di:waypoint x="980" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01iapsa_di" bpmnElement="Flow_01iapsa">
-        <di:waypoint x="1080" y="260" />
-        <di:waypoint x="1172" y="260" />
+        <di:waypoint x="1150" y="260" />
+        <di:waypoint x="1282" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eqfxon_di" bpmnElement="Flow_0eqfxon">
         <di:waypoint x="340" y="260" />
@@ -254,6 +247,20 @@ execution.setVariable('applicationStatus','New');</camunda:script>
         <di:waypoint x="208" y="260" />
         <di:waypoint x="240" y="260" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gikngm_di" bpmnElement="Flow_0gikngm">
+        <di:waypoint x="920" y="190" />
+        <di:waypoint x="980" y="190" />
+        <di:waypoint x="980" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07pivsl_di" bpmnElement="Flow_07pivsl">
+        <di:waypoint x="920" y="330" />
+        <di:waypoint x="980" y="330" />
+        <di:waypoint x="980" y="285" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_107tioi_di" bpmnElement="Flow_107tioi">
+        <di:waypoint x="1005" y="260" />
+        <di:waypoint x="1050" y="260" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="172" y="242" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -262,9 +269,6 @@ execution.setVariable('applicationStatus','New');</camunda:script>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0l4y66o_di" bpmnElement="reviewer">
         <dc:Bounds x="380" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_03cla68_di" bpmnElement="EndEvent_03cla68">
-        <dc:Bounds x="1172" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0l1c65j_di" bpmnElement="ExclusiveGateway_0l1c65j" isMarkerVisible="true">
         <dc:Bounds x="515" y="235" width="50" height="50" />
@@ -277,15 +281,6 @@ execution.setVariable('applicationStatus','New');</camunda:script>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1i967b8_di" bpmnElement="Activity_0kai049">
         <dc:Bounds x="240" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0qjfbs1_di" bpmnElement="send_to_ods">
-        <dc:Bounds x="980" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="DataStoreReference_0iew98f_di" bpmnElement="DataStoreReference_0iew98f">
-        <dc:Bounds x="1005" y="105" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1018" y="81" width="24" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1pmly6k_di" bpmnElement="Activity_0cnvjyo">
         <dc:Bounds x="820" y="150" width="100" height="80" />
@@ -302,9 +297,24 @@ execution.setVariable('applicationStatus','New');</camunda:script>
       <bpmndi:BPMNShape id="TextAnnotation_10vy6xl_di" bpmnElement="TextAnnotation_10vy6xw">
         <dc:Bounds x="380" y="140" width="100" height="54" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qjfbs1_di" bpmnElement="send_to_ods">
+        <dc:Bounds x="1050" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_03cla68_di" bpmnElement="EndEvent_03cla68">
+        <dc:Bounds x="1282" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0urz316_di" bpmnElement="Gateway_1gqg4sz">
+        <dc:Bounds x="955" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_0iew98f_di" bpmnElement="DataStoreReference_0iew98f">
+        <dc:Bounds x="1075" y="105" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1088" y="81" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="DataOutputAssociation_0n0lg8r_di" bpmnElement="DataOutputAssociation_0n0lg8r">
-        <di:waypoint x="1030" y="220" />
-        <di:waypoint x="1030" y="155" />
+        <di:waypoint x="1100" y="220" />
+        <di:waypoint x="1100" y="155" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1tytyjh_di" bpmnElement="Association_1tytyjh">
         <di:waypoint x="870" y="370" />


### PR DESCRIPTION
## Summary
Fixed an issue where the client would receive the adm approval in the Telework form, even if no `attachment` injection was set in the Camunda modeller for that task. 

The issue was that Spring Beans are by default reused, so the `attachment` property was carried over from the other task.

Solution: Annotate the `TaskAssignmentListener` with `@Scope(value = "prototype")` to use a new instance of the class every time it is used.

Reference:
https://docs.spring.io/spring-framework/docs/3.0.0.M3/reference/html/ch04s04.html

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added `@Scope(value = "prototype")` annotation to our listeners that use Field injections
- Added A combining parallell gateway to the Telework form to make sure both email sending tasks complete before sending the submission to the ODS
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

![image](https://user-images.githubusercontent.com/66635118/160928120-f62fc672-2f79-4f32-beba-c26cfeaa8338.png)


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->