### PR TITLE
Added debug flag for ODS sending

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Named("SendSubmissionToODSDelegate")
 public class SendSubmissionToODSDelegate extends BaseListener implements JavaDelegate {
-    private final static Logger LOGGER = LoggerFactory.getLogger(SendSubmissionToODSDelegate.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(SendSubmissionToODSDelegate.class.getName());
 
     @Autowired
     private FormSubmissionService formSubmissionService;
@@ -39,8 +39,9 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
 
     private void sendSubmissionToODS(DelegateExecution execution) throws IOException {
         String formUrl = String.valueOf(execution.getVariable("formUrl"));
+        String endpoint = String.valueOf(execution.getVariableLocal("endpoint"));
 
-        LOGGER.warn(String.format("Sending values of form to ODS %s", formUrl));
+        LOGGER.warn(String.format("Sending values of form to ODS. Form: %s. ODS Endpoint: %s", formUrl, endpoint));
 
         if(formUrl == null || formUrl.length() == 0) {
             return;
@@ -61,9 +62,15 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
 
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(values);
-        String endpoint = (String) execution.getVariableLocal("endpoint");
+
+        boolean debug = Boolean.parseBoolean(String.valueOf(execution.getVariableLocal("debug")));
+
+        if(debug) {
+            System.out.println(json);
+        }
 
         this.httpServiceInvoker.execute(getEndpointUrl(endpoint), HttpMethod.POST, json);
+        LOGGER.warn(String.format("Sent values of form to ODS. Form: %s. ODS Endpoint: %s", formUrl, endpoint));
     }
 
     public String getEndpointUrl(String endpoint) {


### PR DESCRIPTION
## Summary
Added flag to `SendSubmissionToODSDelegate` to enable debugging of ODS submission. Logs a submission payload when enabled
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added debug flag to `SendSubmissionToODSDelegate`
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/66635118/161593956-35527d90-003c-4e5c-a425-21bb6e135ee6.png)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->