### PR TITLE
DGJ-202 Added mapping of postal field

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/employee_data.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data.py
@@ -1,4 +1,9 @@
+####
+# Mapping of data from the ODS that is made available for use in the Form Builder
+###
 class EmployeeData():
+  # data: Response retrieved from the ODS
+  # Spec of possible values can be found at: https://analytics-testapi.psa.gov.bc.ca/apiserver/api.rst#Datamart_Telework_employee_demo
   def __init__(self, data):
    self.name = data["name"]
    self.firstName = data["first_name"]
@@ -6,6 +11,7 @@ class EmployeeData():
    self.email = data["email"]
    self.address1 = data["address1"]
    self.address2 = data["address2"]
+   self.postal = data["postal"]
    self.officePhone = data["office_phone"]
    self.empId = data["EMPLID"]
    self.positionTitle = data["position_title"]

--- a/forms-flow-api/src/formsflow_api/models/employee_data.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data.py
@@ -12,6 +12,7 @@ class EmployeeData():
    self.address1 = data["address1"]
    self.address2 = data["address2"]
    self.postal = data["postal"]
+   self.city = data["city"]
    self.officePhone = data["office_phone"]
    self.empId = data["EMPLID"]
    self.positionTitle = data["position_title"]


### PR DESCRIPTION
## Summary
Added mapping of the ODS `postal` field to be used in the form builder. Currently, only the office postal code is being mapped, which is not what is expected.
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added mapping employee_data mapping of the ODS `postal` field

<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
Available fields to be mapped: https://analytics-testapi.psa.gov.bc.ca/apiserver/api.rst#Datamart_Telework_app_telework_info
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->