### PR TITLE
Create ExtractManagerGUID.java

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/ExtractManagerGUID.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/ExtractManagerGUID.java
@@ -1,0 +1,55 @@
+package org.camunda.bpm.extension.hooks.listeners;
+
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.extension.hooks.services.FormSubmissionService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.inject.Named;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This class transforms all the form document data into CAM variables
+ *
+ * @author sumathi.thirumani@aot-technologies.com
+ */
+@Named("ExtractManagerGUID")
+public class ExtractManagerGUID  extends BaseListener implements TaskListener, ExecutionListener {
+
+    @Autowired
+    private FormSubmissionService formSubmissionService;
+
+    @Override
+    public void notify(DelegateExecution execution) {
+        try {
+            syncFormVariables(execution);
+        } catch (IOException e) {
+            handleException(execution, ExceptionSource.EXECUTION, e);
+        }
+    }
+
+    @Override
+    public void notify(DelegateTask delegateTask) {
+        try {
+            syncFormVariables(delegateTask.getExecution());
+        } catch (IOException e) {
+            handleException(delegateTask.getExecution(), ExceptionSource.TASK, e);
+        }
+    }
+
+    private void syncFormVariables(DelegateExecution execution) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+        String guid = oidcUser.getClaimAsString("bcgovguid");
+        String idir = oidcUser.getClaimAsString("idir");
+
+        execution.setVariable("managerGuid", guid);
+        execution.setVariable("managerIdir", idir);    
+
+    }
+}


### PR DESCRIPTION
Telework: Send the manager's IDIR and GUID to the ODS on submission#208
I would like to send the manager's IDIR and GUID to the ODS on the submission of the telework form so that I have the info available for reporting later.

Acceptance Criteria

When the Telework form is approved by a supervisor (and submitted) both the managers IDIR and GUID get sent to the ODS.
Notes:

Currently only the submitters IDIR and GUID are sent.
See: https://github.com/bcgov/digital-journeys/blob/6e0cca4f56a1910a30d46083fcb72a16b498375e/docs/workflows.md