### PR TITLE
Change DeploymentConfig to Recreate Strategy

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -55,7 +55,7 @@ objects:
           maxUnavailable: 25%
           timeoutSeconds: 600
           updatePeriodSeconds: 1
-        type: Rolling
+        type: Recreate
       template:
         metadata:
           labels:


### PR DESCRIPTION
Try to resolve the deployment issue with CPU resource limits.

## Summary

Recreate Strategy should free up resources before recreating pod(s). Hopefully this will resolve the deployment issue with CPU resource limits.

## Changes

DC > Strategy: Recreate
