### PR TITLE
Fix CPU_LIMIT value and revert startegy to rolling

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -55,7 +55,7 @@ objects:
           maxUnavailable: 25%
           timeoutSeconds: 600
           updatePeriodSeconds: 1
-        type: Recreate
+        type: Rolling
       template:
         metadata:
           labels:
@@ -457,4 +457,4 @@ parameters:
   - name: CPU_LIMIT
     description: CPU Limit for container
     required: true
-    value: "300"
+    value: "300m"


### PR DESCRIPTION
## Summary

The CPU_LIMIT defined in camunda_dc.yaml needs to be updated to the coorect value to prevent replication controller from failing

## Changes
-There was a typo in the CPU_LIMIT value. Changed CPU_LIMIT to 300m"
-Also, strategy needs to be kept as Rolling to avoid downtime while deployment in case of more than replica. 

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->