### PR TITLE
Update camunda_dc.yaml

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -221,29 +221,29 @@ objects:
 
               imagePullPolicy: Always
               livenessProbe:
-                failureThreshold: 3
+                failureThreshold: 4
                 httpGet:
                   path: /camunda/actuator/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 60
-                periodSeconds: 10
+                initialDelaySeconds: 120
+                periodSeconds: 20
                 successThreshold: 1
-                timeoutSeconds: 3
+                timeoutSeconds: 90
               name: ${NAME}
               ports:
                 - containerPort: 8080
                   protocol: TCP
               readinessProbe:
-                failureThreshold: 3
+                failureThreshold: 4
                 httpGet:
                   path: /camunda/actuator/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 60
-                periodSeconds: 60
+                initialDelaySeconds: 120
+                periodSeconds: 120
                 successThreshold: 1
-                timeoutSeconds: 3
+                timeoutSeconds: 4
               resources:
                 limits:
                   cpu: ${CPU_LIMIT}
@@ -457,12 +457,12 @@ parameters:
   - name: MEMORY_LIMIT
     description: MEMORY Limit for container
     required: true
-    value: "3Gi"
+    value: "2Gi"
   - name: CPU_REQUEST
     description: CPU Request for container
     required: true
-    value: "200m"
+    value: "100m"
   - name: CPU_LIMIT
     description: CPU Limit for container
     required: true
-    value: "500m"
+    value: "400m"


### PR DESCRIPTION
Increase liveness/readiness probe limits and decrease CPU/memory limits to avoid ReplicationController failure.