### PR TITLE
manager idir and guid is sent to ODS

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/ExtractManagerGuid.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/ExtractManagerGuid.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.ObjectUtils;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import net.minidev.json.JSONArray;
@@ -62,12 +63,17 @@ public class ExtractManagerGuid  extends BaseListener implements TaskListener, E
     private void syncFormVariables(DelegateExecution execution) throws IOException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
-        String guid = oidcUser.getClaimAsString("bcgovguid");
-        String idir = oidcUser.getClaimAsString("idir");
+        if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
+            Jwt jwt = (Jwt) authentication.getPrincipal();
 
-        execution.setVariable("managerGuid", guid);
-        execution.setVariable("managerIdir", idir);    
+            String guid = jwt.getClaimAsString("bcgovguid");
+            String idir = jwt.getClaimAsString("idir");
 
+            execution.setVariable("managerGuid", guid);
+            execution.setVariable("managerIdir", idir);
+        }
+        else {
+            System.err.println("No authentication found!");
+        }
     }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -49,6 +49,10 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
 
         Object idir = execution.getVariable("IDIR");
         Object guid = execution.getVariable("GUID");
+    
+        Object managerIdir = execution.getVariable("managerIdir");
+        Object managerGuid = execution.getVariable("managerGuid");
+
 
         Map<String, Object> values = formSubmissionService.retrieveFormValues(formUrl, false);
 
@@ -60,13 +64,21 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
             values.put("guid", String.valueOf(guid));
         }
 
+        if(managerIdir != null) {
+            values.put("managerIdir", String.valueOf(managerIdir));
+        }
+
+        if(managerGuid != null) {
+            values.put("managerGuid", String.valueOf(managerGuid));
+        }
+
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(values);
 
         boolean debug = Boolean.parseBoolean(String.valueOf(execution.getVariableLocal("debug")));
 
         if(debug) {
-            System.out.println(json);
+            System.out.println("Sending valuse to ODS: " + json);
         }
 
         this.httpServiceInvoker.execute(getEndpointUrl(endpoint), HttpMethod.POST, json);


### PR DESCRIPTION
## Summary
Manager `idir` and `guid` is sent to ODS

## Changes
- The `ExtractManagerGuid` listener is updated to extract manager's `idir` and `guid`. Orignal work was kindly done by @jizhaogit
- Manager's `idir` and `guid` are added to the payload that is sent to ODS.

@jizhaogit I'd appreciate it if you could review this pr since you have context on that. 