### PR TITLE
display name was added to employee user data

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -45,9 +45,10 @@ Step 3: If you want to use one piece of user data more than once in a form, you 
 
 | Property Name            | Description |
 | ------------------------ | ----------- |
-| `name`                     | first and last name of employee|
+| `name`                     | first and last name of employee as retuned from ODS|
 | `firstName`                | first name of employee|
 | `lastName`                 | last name of employee|
+| `displayName`              | A calculated value based on `firstName` + `lastName` of employee|
 | `email`                    | email of employee|
 | `address1`                 | home address1 of employee|
 | `address2`                 | home address2 of employee|

--- a/forms-flow-api/src/formsflow_api/models/employee_data.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data.py
@@ -5,6 +5,7 @@ class EmployeeData():
   # data: Response retrieved from the ODS
   # Spec of possible values can be found at: https://analytics-testapi.psa.gov.bc.ca/apiserver/api.rst#Datamart_Telework_employee_demo
   def __init__(self, data):
+   self.displayName = data["first_name"] + " " + data["last_name"]
    self.name = data["name"]
    self.firstName = data["first_name"]
    self.lastName = data["last_name"]


### PR DESCRIPTION
## Summary

Adding a new field to employee data called `displayName` to properly show first and last names.

This PR fixes the issue reported in #290 . The `name` filed, coming from ODS, does not have the format that the PSA team wants, so I made a calculated one that guarantees it is always the first name followed by the last name.