### PR TITLE
Remove image change triggers

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -273,15 +273,6 @@ objects:
       test: false
       triggers:
       - type: ConfigChange
-      - imageChangeParams:
-          automatic: true
-          containerNames:
-          - ${NAME}
-          from:
-            kind: ImageStreamTag
-            name: ${NAME}:${IMAGE_TAG}
-            namespace: ${TOOLS_WORKSPACE}
-        type: ImageChange
 
 parameters:
   - name: NAME

--- a/deployment/openshift/web_dc.yaml
+++ b/deployment/openshift/web_dc.yaml
@@ -68,15 +68,6 @@ objects:
       test: false
       triggers:
         - type: ConfigChange
-        - imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              namespace: "${IMAGE_NAMESPACE}"
-              name: "${NAME}:${TAG_NAME}"
-          type: ImageChange
     status: {}
 
   -

--- a/deployment/openshift/webapi_dc.yaml
+++ b/deployment/openshift/webapi_dc.yaml
@@ -153,15 +153,6 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - ${NAME}
-        from:
-          kind: ImageStreamTag
-          namespace: "${IMAGE_NAMESPACE}"
-          name: "${NAME}:${TAG_NAME}"
-      type: ImageChange
   status: {}
 
 -


### PR DESCRIPTION
## Summary

Deployments in all 3 environments are getting triggered whenever there is a change to the imagestream image. 

## Changes
Image triggers need to be removed from the deployment configurations to fix this.

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->