### PR TITLE
DGJ-448 Fix auth issue when uploading ADM approval attachment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
       - REACT_APP_USER_ACCESS_PERMISSIONS=${USER_ACCESS_PERMISSIONS}
       - REACT_APP_WEB_BASE_CUSTOM_URL=${WEB_BASE_CUSTOM_URL:-}
       - REACT_APP_FORMIO_JWT_SECRET=${FORMIO_JWT_SECRET:---- change me now ---}
-      - REACT_APP_FORMIO_FILE_URL=${FORMIO_FILE_URL}
+      - REACT_APP_FORMIO_FILE_URL=${FORMIO_FILE_URL_ATTACHMENTS}
     volumes:
       - ".:/forms-flow"
       - "/forms-flow/node_modules"

--- a/forms-flow-web/src/formComponents/UploadProvider/index.js
+++ b/forms-flow-web/src/formComponents/UploadProvider/index.js
@@ -93,12 +93,12 @@ const url = (formio) => {
     title: 'Digital Journeys',
     name: 'digital-journeys',
     uploadFile(file, name, dir, progressCallback, url, options, fileKey, groupPermissions, groupId, abortCallback) {
-      const uploadRequest = function(form) {
-
+      const uploadRequest = function(form, submissionId) {
         return xhrRequest(FORMIO_FILE_URL, name, {
           baseUrl: encodeURIComponent(formio.projectUrl),
           project: form ? form.project || 'dgj' : '',
-          form: form ? form._id : ''
+          form: form ? form._id : '',
+          submission: submissionId || '',
         }, {
           [fileKey]:file,
           name,
@@ -119,8 +119,11 @@ const url = (formio) => {
           };
         });
       };
+
+
+
       if (formio.formId) {
-        return formio.loadForm().then((form) => uploadRequest(form));
+        return formio.loadForm().then((form) => uploadRequest(form, formio.submissionId));
       }
       else {
         return uploadRequest();


### PR DESCRIPTION
## Summary
Fixes `401` error when trying to upload ADM approval attachments. Submission ID was not passed along to the file upload service, causing the error when authenticating with Formio

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Pass along submission ID to file upload service when uploading file to submission
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->