### PR TITLE
DGJ-416 Enable cleanup of telework form submission history

### DIFF
--- a/forms-flow-bpm/processes/telework-form.bpmn
+++ b/forms-flow-bpm/processes/telework-form.bpmn
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0993co4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
-  <bpmn:process id="teleworkform" name="Telework Form" isExecutable="true" camunda:versionTag="4">
+  <bpmn:process id="teleworkform" name="Telework Form" isExecutable="true" camunda:versionTag="4" camunda:historyTimeToLive="0">
     <bpmn:startEvent id="StartEvent_1" name="Submitted Form">
       <bpmn:outgoing>SequenceFlow_0ociprs</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="reviewer" name="Review ${name}'s Request" camunda:assignee="${managerEmail}" camunda:candidateUsers="${managerEmail}">
+    <bpmn:userTask id="reviewer" name="Review ${name}&#39;s Request" camunda:assignee="${managerEmail}" camunda:candidateUsers="${managerEmail}">
       <bpmn:extensionElements>
         <camunda:formData>
           <camunda:formField id="action" label="Action" type="string" />

--- a/forms-flow-bpm/src/main/resources/application.yaml
+++ b/forms-flow-bpm/src/main/resources/application.yaml
@@ -79,6 +79,11 @@ info:
     version: "11"
 
 camunda.bpm:
+  generic-properties:
+    properties:
+      historyCleanupBatchWindowStartTime: "01:00"
+      historyCleanupBatchWindowEndTime: "05:00"
+
   history-level: ${CAMUNDA_BPM_HISTORY_LEVEL:none}
   authorization:
     enabled: ${CAMUNDA_AUTHORIZATION_FLAG:true}


### PR DESCRIPTION
## Summary
Remove finished Telework form processes from after submission. Doing this by setting "time to live" to 0 days, which means that it will be cleaned out of the DB during the first history Cleanup Batch Window after completion.

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added history ttl to telework form bpmn
- Added historyCleanupBatchWindow (daily, 1am - 5am)
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->