### PR TITLE
DGJ-459 Use manager role to determine task tab visibility

### DIFF
--- a/forms-flow-bpm/processes/telework-form.bpmn
+++ b/forms-flow-bpm/processes/telework-form.bpmn
@@ -52,7 +52,7 @@ Thank you.</camunda:expression>
         <camunda:taskListener class="org.camunda.bpm.extension.hooks.listeners.ExtractManagerGuid" event="complete" id="getManagerGuid" />
         <camunda:taskListener class="org.camunda.bpm.extension.hooks.listeners.UserGroupAssignmentListener" event="create" id="user-group-assigned">
           <camunda:field name="groupPath">
-            <camunda:string>/formsflow/formsflow-reviewer</camunda:string>
+            <camunda:string>/formsflow/manager</camunda:string>
           </camunda:field>
         </camunda:taskListener>
       </bpmn:extensionElements>

--- a/forms-flow-web/src/components/ServiceFlow/details/TaskHeader.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/TaskHeader.js
@@ -168,7 +168,7 @@ const TaskHeader = React.memo(() => {
       <Row className="ml-0" >
       <span data-title="Application Id" className="application-id"> Application ID# {task?.applicationId}</span>
       </Row>
-      { !getUserRolePermission(userRoles, STAFF_REVIEWER) 
+      {/* { getUserRolePermission(userRoles, STAFF_REVIEWER) 
           &&
         <Row className="actionable mb-4">
           <Col sm={followUpDate?2:"auto"} data-title={followUpDate?getFormattedDateAndTime(followUpDate):'Set FollowUp Date'} className='date-container'>
@@ -235,7 +235,7 @@ const TaskHeader = React.memo(() => {
             }
           </Col>
         </Row>
-      }
+      } */}
     </>
   );
 });

--- a/forms-flow-web/src/constants/constants.js
+++ b/forms-flow-web/src/constants/constants.js
@@ -35,6 +35,7 @@ export const STAFF_REVIEWER =
   process.env.REACT_APP_STAFF_REVIEWER_ROLE;
 export const ANONYMOUS_USER = "anonymous";
 
+export const MANAGER_GROUP = 'manager';
 
 export const FORMIO_JWT_SECRET =
   (window._env_ && window._env_.REACT_APP_FORMIO_JWT_SECRET) || process.env.REACT_APP_FORMIO_JWT_SECRET;

--- a/forms-flow-web/src/containers/NavBar.jsx
+++ b/forms-flow-web/src/containers/NavBar.jsx
@@ -8,7 +8,7 @@ import { useHistory } from "react-router-dom";
 import Navigation from "@button-inc/bcgov-theme/Navigation";
 
 import "./styles.scss";
-import {CLIENT, STAFF_REVIEWER, APPLICATION_NAME, STAFF_DESIGNER} from "../constants/constants";
+import {CLIENT, STAFF_REVIEWER, APPLICATION_NAME, STAFF_DESIGNER, MANAGER_GROUP} from "../constants/constants";
 import ServiceFlowFilterListDropDown from "../components/ServiceFlow/filter/ServiceTaskFilterListDropDown";
 import {push} from "connected-react-router";
 
@@ -75,7 +75,7 @@ const NavBar = React.memo(() => {
         Applications
       </Link>
     : null,
-    <Link
+    (getUserRolePermission(userRoles, MANAGER_GROUP) || getUserRolePermission(userRoles, STAFF_REVIEWER)) && <Link
       className={pathname.match(/^\/task/)? 'active': null}
       to='/task'
     >
@@ -83,6 +83,10 @@ const NavBar = React.memo(() => {
     </Link>,
     (!getUserRolePermission(userRoles, STAFF_REVIEWER) && !getUserRolePermission(userRoles, CLIENT)) ? analyticsDropdown(): null,
   ];
+
+  const items = navItems()
+    .filter(item => item)
+    .map(item => <li>{item}</li>);
 
   return (
     <Navigation
@@ -98,14 +102,12 @@ const NavBar = React.memo(() => {
           ): null}
         </>
       }>
-        {isAuthenticated && <div>
+        {isAuthenticated && <div class={items?.length? 'menu-padded': ''}>
           <ul>
             <div className="sign-out-button">
               <Button onClick={logout} variant="outline-light">Sign Out</Button>
             </div>
-            {navItems()
-              .filter(item => item)
-              .map(item => <li>{item}</li>)}
+            {items}
           </ul>
           </div>}
     </Navigation>

--- a/forms-flow-web/src/containers/styles.scss
+++ b/forms-flow-web/src/containers/styles.scss
@@ -22,3 +22,11 @@
     display: none;
   }
 }
+
+.pg-menu-container + .pg-menu-container {
+  padding: 0;
+}
+
+.menu-padded {
+  padding: 5px 0 5px 0;
+}


### PR DESCRIPTION
## Summary
- Use the `manager` role to determine whether or not tasks tab should show up
- Grant `formsflow/manager` group assignment to manager when telework form has been submitted
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->