### PR TITLE
Enabled automated MongoDB backups for formiodb

### DIFF
--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -1,6 +1,10 @@
 name: Deploy backup container to Openshift
 
 on:
+  push:
+    branches:
+      - automated-db-backups
+
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Log in to OpenShift
         run: oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
 
-      - name: Deploy Backup container - MongoDB Dev
+      - name: Deploy Backup container
         run: |
           test -n "${NAMESPACE}"
           test -n "${BUILD_NAMESPACE}"

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -33,8 +33,8 @@ jobs:
           echo BUILD ID: $BUILD_ID
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
       
-      # - name: Checkout Target Branch
-      #   uses: actions/checkout@v1
+      - name: Checkout Target Branch
+        uses: actions/checkout@v1
       
       # Log in to OpenShift.
       # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
@@ -45,7 +45,7 @@ jobs:
 
       # Build backup container
       - name: Build backup image
-        working-directory: 'deployment/openshift'
+        working-directory: './deployment/openshift'
         run: |
           oc -n ${BUILD_NAMESPACE} process -f docker-build.yml \
           -p NAME=${DB_BACKUP_APP} \
@@ -75,8 +75,8 @@ jobs:
     needs:
       - build
     steps:
-      # - name: Checkout Target Branch
-      #   uses: actions/checkout@v1
+      - name: Checkout Target Branch
+        uses: actions/checkout@v1
       
       # Log in to OpenShift.
       # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -6,16 +6,6 @@ on:
       - automated-db-backups
 
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment'
-        required: true
-        default: 'dev'
-        type: choice
-        options:
-        - dev
-        - test
-        - production
 
 jobs:
   # build the backup mongo container
@@ -62,7 +52,6 @@ jobs:
 
   # deploy the backup image in Dev
   deployDev:
-    if: ${{github.event.inputs.environment == 'dev'}}
     name: Deploy DB_BACKUP_APP to Dev environment
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -10,6 +10,7 @@ on:
       environment:
         description: 'Environment'
         required: true
+        default: 'dev'
         type: choice
         options:
         - dev

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -1,0 +1,108 @@
+name: Deploy backup container to Openshift
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'
+        required: true
+        type: choice
+        options:
+        - dev
+        - test
+        - production
+
+jobs:
+  # build the backup mongo container
+  build:
+    name: 'Build APP'
+    runs-on: ubuntu-latest
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      BUILD_NAMESPACE: d89793-tools
+      BUILD_TAG: latest
+      DB_BACKUP_APP: mongodb-backup
+    steps:
+      # Checkout the PR branch
+      - name: Print env
+        run: |
+          echo BUILD ID: $BUILD_ID
+          echo BUILD NAMESPACE: $BUILD_NAMESPACE
+      
+      # - name: Checkout Target Branch
+      #   uses: actions/checkout@v1
+      
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      # Build backup container
+      - name: Build backup image
+        working-directory: './deployment/openshift'
+        run: |
+          oc -n ${BUILD_NAMESPACE} process -f docker-build.yml \
+          -p NAME=${DB_BACKUP_APP} \
+          -p TAG=${BUILD_TAG} \
+          -p BASE_IMAGE_NAME="mongodb-36-rhel7" \
+          -p BASE_IMAGE_TAG="1" \
+          -p BASE_IMAGE_REPO="registry.redhat.io/rhscl/" \
+          -p GITHUB_AUTH_TOKEN=${{secrets.AUTH_TOKEN}} \
+          -p SOURCE_REPOSITORY_URL="https://github.com/BCDevOps/backup-container.git" \
+          -p SOURCE_REPOSITORY_REF="master" \
+          -p SOURCE_CONTEXT_DIR="docker" | oc -n ${BUILD_NAMESPACE} apply -f - 
+
+          oc -n ${BUILD_NAMESPACE} start-build bc/${DB_BACKUP_APP} --wait
+
+  # deploy the backup image in Dev
+  deployDev:
+    if: ${{github.event.inputs.environment == 'dev'}}
+    name: Deploy DB_BACKUP_APP to Dev environment
+    runs-on: ubuntu-latest
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      NAMESPACE: d89793-dev
+      BUILD_NAMESPACE: d89793-tools
+      BRANCH: automated-db-backups
+      DB_BACKUP_APP: mongodb-backup
+      DB_NAME: formiodb
+    needs:
+      - build
+    steps:
+      # - name: Checkout Target Branch
+      #   uses: actions/checkout@v1
+      
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      - name: Deploy Backup container - MongoDB Dev
+        run: |
+          test -n "${NAMESPACE}"
+          test -n "${BUILD_NAMESPACE}"
+          test -n "${BRANCH}"
+          echo "Current namespace is ${NAMESPACE}"
+
+          oc -n ${NAMESPACE} process -f deployment/openshift/databases/db-backup-deploy.yaml \
+          -p NAME=${DB_BACKUP_APP} \
+          -p IMAGE_STREAM_TAG=${DB_BACKUP_APP}:latest \
+          -p BUILD_NAMESPACE=${BUILD_NAMESPACE} \
+          -p DB_NAME=${DB_NAME}  | oc -n ${NAMESPACE} apply -f -
+
+          sleep 30
+          oc rollout latest dc/${DB_BACKUP_APP} -n ${NAMESPACE}
+
+          # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.
+          ATTEMPTS=0
+          ROLLOUT_STATUS_CMD="oc rollout status dc/db-backup -n ${NAMESPACE}"
+          until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq 60 ]; do
+            $ROLLOUT_STATUS_CMD
+            ATTEMPTS=$((attempts + 1))
+            sleep 10
+          done
+          oc project ${NAMESPACE}     
+          echo "Listing pods.."

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -97,3 +97,97 @@ jobs:
             ATTEMPTS=$((attempts + 1))
             sleep 10
           done
+
+  deployTest:
+    name: Deploy DB_BACKUP_APP to Test environment
+    runs-on: ubuntu-latest
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      NAMESPACE: d89793-test
+      BUILD_NAMESPACE: d89793-tools
+      BRANCH: automated-db-backups
+      DB_BACKUP_APP: mongodb-backup
+      DB_NAME: formiodb
+    needs:
+      - build
+    steps:
+      - name: Checkout Target Branch
+        uses: actions/checkout@v1
+      
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      - name: Deploy Backup container - MongoDB
+        run: |
+          test -n "${NAMESPACE}"
+          test -n "${BUILD_NAMESPACE}"
+          test -n "${BRANCH}"
+          echo "Current namespace is ${NAMESPACE}"
+
+          oc -n ${NAMESPACE} process -f deployment/openshift/databases/mongo-backup-deploy.yaml \
+          -p NAME=${DB_BACKUP_APP} \
+          -p IMAGE_STREAM_TAG=${DB_BACKUP_APP}:latest \
+          -p BUILD_NAMESPACE=${BUILD_NAMESPACE} \
+          -p DB_NAME=${DB_NAME}  | oc -n ${NAMESPACE} apply -f -
+
+          sleep 30
+          oc rollout latest dc/${DB_BACKUP_APP} -n ${NAMESPACE}
+
+          # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.
+          ATTEMPTS=0
+          ROLLOUT_STATUS_CMD="oc rollout status dc/${DB_BACKUP_APP} -n ${NAMESPACE}"
+          until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq 60 ]; do
+            $ROLLOUT_STATUS_CMD
+            ATTEMPTS=$((attempts + 1))
+            sleep 10
+          done
+
+  deployProd:
+    name: Deploy DB_BACKUP_APP to Prod environment
+    runs-on: ubuntu-latest
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      NAMESPACE: d89793-prod
+      BUILD_NAMESPACE: d89793-tools
+      BRANCH: automated-db-backups
+      DB_BACKUP_APP: mongodb-backup
+      DB_NAME: formiodb
+    needs:
+      - build
+    steps:
+      - name: Checkout Target Branch
+        uses: actions/checkout@v1
+      
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      - name: Deploy Backup container
+        run: |
+          test -n "${NAMESPACE}"
+          test -n "${BUILD_NAMESPACE}"
+          test -n "${BRANCH}"
+          echo "Current namespace is ${NAMESPACE}"
+
+          oc -n ${NAMESPACE} process -f deployment/openshift/databases/mongo-backup-deploy.yaml \
+          -p NAME=${DB_BACKUP_APP} \
+          -p IMAGE_STREAM_TAG=${DB_BACKUP_APP}:latest \
+          -p BUILD_NAMESPACE=${BUILD_NAMESPACE} \
+          -p DB_NAME=${DB_NAME}  | oc -n ${NAMESPACE} apply -f -
+
+          sleep 30
+          oc rollout latest dc/${DB_BACKUP_APP} -n ${NAMESPACE}
+
+          # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.
+          ATTEMPTS=0
+          ROLLOUT_STATUS_CMD="oc rollout status dc/${DB_BACKUP_APP} -n ${NAMESPACE}"
+          until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq 60 ]; do
+            $ROLLOUT_STATUS_CMD
+            ATTEMPTS=$((attempts + 1))
+            sleep 10
+          done

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -53,7 +53,6 @@ jobs:
           -p BASE_IMAGE_NAME="mongodb-36-rhel7" \
           -p BASE_IMAGE_TAG="1" \
           -p BASE_IMAGE_REPO="registry.redhat.io/rhscl/" \
-          -p GITHUB_AUTH_TOKEN=${{secrets.AUTH_TOKEN}} \
           -p SOURCE_REPOSITORY_URL="https://github.com/BCDevOps/backup-container.git" \
           -p SOURCE_REPOSITORY_REF="master" \
           -p SOURCE_CONTEXT_DIR="docker" | oc -n ${BUILD_NAMESPACE} apply -f - 

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -91,11 +91,9 @@ jobs:
 
           # Check deployment rollout status every 10 seconds (max 10 minutes) until complete.
           ATTEMPTS=0
-          ROLLOUT_STATUS_CMD="oc rollout status dc/db-backup -n ${NAMESPACE}"
+          ROLLOUT_STATUS_CMD="oc rollout status dc/${DB_BACKUP_APP} -n ${NAMESPACE}"
           until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq 60 ]; do
             $ROLLOUT_STATUS_CMD
             ATTEMPTS=$((attempts + 1))
             sleep 10
           done
-          oc project ${NAMESPACE}     
-          echo "Listing pods.."

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -91,7 +91,7 @@ jobs:
           test -n "${BRANCH}"
           echo "Current namespace is ${NAMESPACE}"
 
-          oc -n ${NAMESPACE} process -f deployment/openshift/databases/db-backup-deploy.yaml \
+          oc -n ${NAMESPACE} process -f deployment/openshift/databases/mongo-backup-deploy.yaml \
           -p NAME=${DB_BACKUP_APP} \
           -p IMAGE_STREAM_TAG=${DB_BACKUP_APP}:latest \
           -p BUILD_NAMESPACE=${BUILD_NAMESPACE} \

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -45,7 +45,7 @@ jobs:
 
       # Build backup container
       - name: Build backup image
-        working-directory: './deployment/openshift'
+        working-directory: 'deployment/openshift'
         run: |
           oc -n ${BUILD_NAMESPACE} process -f docker-build.yml \
           -p NAME=${DB_BACKUP_APP} \

--- a/.github/workflows/mongo_backup.yaml
+++ b/.github/workflows/mongo_backup.yaml
@@ -109,7 +109,7 @@ jobs:
       DB_BACKUP_APP: mongodb-backup
       DB_NAME: formiodb
     needs:
-      - build
+      - deployDev
     steps:
       - name: Checkout Target Branch
         uses: actions/checkout@v1
@@ -156,7 +156,7 @@ jobs:
       DB_BACKUP_APP: mongodb-backup
       DB_NAME: formiodb
     needs:
-      - build
+      - deployTest
     steps:
       - name: Checkout Target Branch
         uses: actions/checkout@v1

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongodb/${DB_NAME}
+        mongo = database/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongo=mongodb/${DB_NAME}
+        mongo=${DATABASE_SERVICE_NAME}/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongo=${NAME}/${DB_NAME}
+        mongodb/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongo = database/${DB_NAME}
+        mongo = hamongo-internal/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongo=${DATABASE_SERVICE_NAME}/${DB_NAME}
+        mongo=${NAME}/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -30,7 +30,7 @@ objects:
       name: ${NAME}-config
     data:
       backup.conf: |
-        mongo = hamongo-internal/${DB_NAME}
+        hamongo-internal/${DB_NAME}
         0 9 * * * default ./backup.sh -s
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig

--- a/deployment/openshift/databases/mongo-backup-deploy.yaml
+++ b/deployment/openshift/databases/mongo-backup-deploy.yaml
@@ -1,0 +1,189 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ${NAME}
+objects:
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: ${NAME}-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${DATA_VOLUME_SIZE}
+      storageClassName: netapp-file-backup
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: ${NAME}-verification
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: "${VERIFICATION_VOLUME_SIZE}"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: ${NAME}-config
+    data:
+      backup.conf: |
+        mongo=mongodb/${DB_NAME}
+        0 9 * * * default ./backup.sh -s
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${NAME}
+    spec:
+      replicas: "${{REPLICAS}}"
+      revisionHistoryLimit: 10
+      selector:
+        deploymentconfig: ${NAME}
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ConfigChange
+      template:
+        metadata:
+          labels:
+            deploymentconfig: ${NAME}
+        spec:
+          volumes:
+          - name: ${NAME}-data-vol
+            persistentVolumeClaim:
+              claimName: "${NAME}-data"
+          - name: ${NAME}-verification-vol
+            persistentVolumeClaim:
+              claimName: ${NAME}-verification
+          - name: ${NAME}-config-vol
+            configMap:
+              name: ${NAME}-config
+              items:
+              - key: backup.conf
+                path: backup.conf
+          containers:
+            - env:
+              - name: BUILD_ID
+                value: ${BUILD_ID}
+              - name: BACKUP_STRATEGY
+                value: rolling
+              - name: BACKUP_DIR
+                value: "/backups/"
+              - name: DAILY_BACKUPS
+                value: '5'
+              - name: WEEKLY_BACKUPS
+                value: '1'
+              - name: MONTHLY_BACKUPS
+                value: '1'
+              - name: MONGODB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: ${DB_USERNAME_KEY}
+              - name: DATABASE_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: ${DB_SECRET_NAME}
+                    key: ${DB_USERNAME_KEY}
+              - name: MONGODB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: ${DB_PASSWORD_KEY}
+                    name: ${DB_SECRET_NAME}
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: ${DB_PASSWORD_KEY}
+                    name: ${DB_SECRET_NAME}
+              - name: MONGODB_DATABASE
+                value: ${DB_NAME}
+              - name: DATABASE_NAME
+                value: ${DB_NAME}
+              - name: DATABASE_SERVER_TIMEOUT
+                value: '600'
+              - name: ENVIRONMENT_NAME
+                value: "${ENVIRONMENT_NAME}"
+              - name: ENVIRONMENT_FRIENDLY_NAME
+                value: "${ENVIRONMENT_FRIENDLY_NAME}"
+              - name: DATABASE_SERVICE_NAME
+                value: ${DB_SERVICE}
+              image: ${IMAGE_REGISTRY}/${BUILD_NAMESPACE}/${IMAGE_STREAM_TAG}
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: "${{PORT}}"
+              resources:
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+              volumeMounts:
+              - name: ${NAME}-data-vol
+                mountPath: "/backups/"
+              - name: ${NAME}-verification-vol
+                mountPath: "/var/lib/mongodb/data"
+              - name: ${NAME}-config-vol
+                mountPath: "/backup.conf"
+                subPath: backup.conf
+parameters:
+  - name: NAME
+    required: true
+  # - name: PROJECT 
+  #   value: digital_journeys
+  # - name: SERVICE_NAME
+  #   value: db-backup
+  - name: CPU_LIMIT
+    value: "1"
+  - name: MEMORY_LIMIT
+    value: "512M"
+  - name: CPU_REQUEST
+    value: "0.5"
+  - name: MEMORY_REQUEST
+    value: "256M"
+  - name: REPLICAS
+    value: "1"
+  - name: PORT
+    value: "27017"
+  - name: DB_SERVICE
+    value: hamongo-0.hamongo
+  - name: DB_SECRET_NAME
+    value: mongodb-creds
+  - name: DB_USERNAME_KEY
+    value: username
+  - name: DB_PASSWORD_KEY
+    value: password
+  # - name: DB_NAME_KEY
+  #   value: database
+  # - name: APP_DB
+  #   value: forms-flow-db
+  - name: IMAGE_STREAM_TAG
+    required: true  
+  - name: BUILD_NAMESPACE
+    required: true
+  - name: IMAGE_REGISTRY
+    value: image-registry.openshift-image-registry.svc:5000
+  - name: DB_NAME
+    required: true
+  - name: VERIFICATION_VOLUME_SIZE
+    displayName: Persistent Volume Size
+    description: The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
+    required: true
+    value: 1Gi
+  - name: ENVIRONMENT_NAME
+    displayName: Environment Name (Environment Id)
+    description: The name or Id of the environment.  This variable is used by the webhook
+      integration to identify the environment in which the backup notifications originate.
+    required: false
+    value: digital_journeys
+  - name: ENVIRONMENT_FRIENDLY_NAME
+    value: digital_journeys
+  - name: DATA_VOLUME_SIZE
+    required: true
+    value: 5Gi
+  - name: BUILD_ID
+    required: false
+  

--- a/deployment/openshift/docker-build.yml
+++ b/deployment/openshift/docker-build.yml
@@ -1,0 +1,97 @@
+  
+# Generalised template for building from Dockerfile in a git repo.
+# Includes importing the base image as an imagestream.
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: ${BASE_IMAGE_NAME}
+    spec:
+      lookupPolicy:
+        local: false
+  - apiVersion: v1
+    kind: ImageStreamTag
+    lookupPolicy:
+      local: false
+    metadata:
+      name: ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+    tag:
+      annotations: null
+      from:
+        kind: DockerImage
+        name: ${BASE_IMAGE_REPO}${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+    spec:
+      lookupPolicy:
+        local: false
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      name: ${NAME}
+    spec:
+      resources:
+        limits:
+          cpu: ${CPU_LIMIT}
+          memory: ${MEMORY_LIMIT}
+        requests:
+          cpu: ${CPU_REQUEST}
+          memory: ${MEMORY_REQUEST}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "${NAME}:${TAG}"
+      runPolicy: SerialLatestOnly
+      source:
+        contextDir: "${SOURCE_CONTEXT_DIR}"
+        git:
+          uri: "${SOURCE_REPOSITORY_URL}"
+          ref: "${SOURCE_REPOSITORY_REF}"
+        type: Git
+      strategy:
+        dockerStrategy: 
+          from:
+            kind: ImageStreamTag
+            name: ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+          buildArgs: 
+            - name: GITHUB_AUTH_TOKEN
+              value: ${GITHUB_AUTH_TOKEN}
+        type: Docker
+parameters:
+  - name: NAME
+    required: true
+  - name: SUFFIX
+  - name: SOURCE_CONTEXT_DIR
+    required: true
+  - name: SOURCE_REPOSITORY_URL
+    required: true
+    value: https://github.com/bcgov/digital-journeys.git
+  - name: SOURCE_REPOSITORY_REF
+    required: true
+  - name: TAG
+    value: "latest"
+  - name: BASE_IMAGE_REPO
+  - name: BASE_IMAGE_NAME
+    required: true
+  - name: BASE_IMAGE_TAG
+    required: true
+  - name: CPU_LIMIT
+    value: "4"
+  - name: MEMORY_LIMIT
+    value: "8Gi"
+  - name: CPU_REQUEST
+    value: "2"
+  - name: MEMORY_REQUEST
+    value: "8Gi"
+  - name: GITHUB_AUTH_TOKEN
+    required: true

--- a/deployment/openshift/docker-build.yml
+++ b/deployment/openshift/docker-build.yml
@@ -63,9 +63,6 @@ objects:
           from:
             kind: ImageStreamTag
             name: ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
-          buildArgs: 
-            - name: GITHUB_AUTH_TOKEN
-              value: ${GITHUB_AUTH_TOKEN}
         type: Docker
 parameters:
   - name: NAME
@@ -93,5 +90,3 @@ parameters:
     value: "2"
   - name: MEMORY_REQUEST
     value: "8Gi"
-  - name: GITHUB_AUTH_TOKEN
-    required: true


### PR DESCRIPTION
## Summary

Issue: Set up automated backups of MongoDB instance #65

Enabled automated MongoDB backups for formiodb to support accidental corruption or removal of data to recover from.
- Deployment Config up and running for all environments `Dev`, `Test`, and `Prod`

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->
- Added a new github workflow to trigger the build and deployment of the backup MongoDB instance
- Base image is reference from `https://github.com/BCDevOps/backup-container` as suggested [here - BC DevHub for container backups](https://developer.gov.bc.ca/Backup-Container)
- The changes will be triggered on push to `automated-db-backups` branch

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/87394256/181237732-4c80da4b-78ae-4d94-8fd4-0b71e2a0c776.png">


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->