### PR TITLE
form-edit-save-process-fixed

### DIFF
--- a/forms-flow-web/src/apiManager/services/processServices.js
+++ b/forms-flow-web/src/apiManager/services/processServices.js
@@ -1,0 +1,218 @@
+ /* istanbul ignore file */
+import { httpGETRequest,httpPOSTRequest, httpPUTRequest } from "../httpRequestHandler";
+import API from "../endpoints";
+import {
+  setProcessStatusLoading,
+  setProcessList,
+  setProcessActivityLoadError,
+  setProcessLoadError,
+  setAllProcessList,
+  setFormProcessesData,
+  setFormProcessLoadError,
+  setProcessActivityData,
+  setProcessDiagramXML,
+  setProcessDiagramLoading,
+  setFormPreviosData,
+} from "../../actions/processActions";
+import { replaceUrl } from "../../helper/helper";
+import UserService from "../../services/UserService";
+import { toast } from "react-toastify";
+
+export const getProcessStatusList = (processId, taskId) => {
+  return (dispatch) => {
+    dispatch(setProcessStatusLoading(true));
+    dispatch(setProcessLoadError(false));
+    const apiUrlProcessId = replaceUrl(
+      API.PROCESS_STATE,
+      "<process_key>",
+      processId
+    );
+
+    const apiURLWithtaskId = replaceUrl(apiUrlProcessId, "<task_key>", taskId);
+
+    httpGETRequest(apiURLWithtaskId)
+      .then((res) => {
+        if (res.data) {
+          dispatch(setProcessStatusLoading(false));
+          dispatch(setProcessLoadError(false));
+          dispatch(setProcessList(res.data.status));
+        } else {
+          dispatch(setProcessStatusLoading(false));
+          dispatch(setProcessList([]));
+          dispatch(setProcessLoadError(true));
+        }
+      })
+      .catch((error) => {
+        dispatch(setProcessStatusLoading(false));
+        dispatch(setProcessLoadError(true));
+      });
+  };
+};
+
+/**
+ *
+ * @param  {...any} rest
+ */
+export const fetchAllBpmProcesses = (...rest) => {
+  const done = rest.length ? rest[0] : () => {};
+  return (dispatch) => {
+    httpGETRequest(API.PROCESSES, {}, UserService.getToken(), true)
+      .then((res) => {
+        if (res.data) {
+          dispatch(setAllProcessList(res.data.process));
+          done(null, res.data);
+        } else {
+          dispatch(setAllProcessList([]));
+          dispatch(setProcessLoadError(true));
+        }
+      })
+      .catch((error) => {
+        // dispatch(setProcessStatusLoading(false));
+        dispatch(setProcessLoadError(true));
+      });
+  };
+};
+
+/**
+ *
+ * @param  {...any} rest
+ */
+export const getFormProcesses = (formId, ...rest) => {
+  const done = rest.length ? rest[0] : () => {};
+  return (dispatch) => {
+    httpGETRequest(
+      `${API.FORM_PROCESSES}/${formId}`,
+      {},
+      UserService.getToken(),
+      true
+    )
+      .then((res) => {
+        if (res.data) {
+          dispatch(setFormPreviosData(res.data));
+          dispatch(setFormProcessesData(res.data)); // need to check api and put exact respose
+          done(null, res.data);
+        } else {
+          dispatch(setFormPreviosData([]))
+          dispatch(setFormProcessesData([]));
+          dispatch(setProcessLoadError(true));
+        }
+      })
+      .catch((error) => {
+        // dispatch(setProcessStatusLoading(false));
+        dispatch(setFormProcessLoadError(true));
+      });
+  };
+};
+
+export const saveFormProcessMapper = (data, update = false, ...rest) => {
+  const done = rest.length ? rest[0] : () => {};
+  return (dispatch) => {
+    let request;
+
+    if (update) {
+      request = httpPUTRequest(`${API.FORM}/${data.id}`, data).then(async(res) => {
+         if(res.data){
+        // dispatch(setFormProcessesData(res.data));
+         done(null, res.data);
+         }
+         else{
+          dispatch(setFormProcessesData([]));
+          done(null, []);
+         }
+         // dispatch(setFormProcessesData([]));
+       })
+       .catch((error) => {
+         dispatch(getFormProcesses(data.formId));
+         dispatch(setFormProcessesData([]));
+         toast.error("Form process failed");
+         console.log("Error", error);
+         dispatch(setFormProcessLoadError(true));
+         done(error);
+       });
+    } else {
+        httpPOSTRequest(`${API.FORM}`, data).then(async(res) => {
+
+         if(res.data){  
+          //  dispatch(getApplicationCount(res.data.id));
+           dispatch(setFormProcessesData(res.data));
+           done(null, res.data);
+         }
+         else{
+          dispatch(setFormProcessesData([]));
+          done(null, []);
+         }
+       })
+       .catch((error) => {
+         dispatch(getFormProcesses(data.formId));
+         toast.error("Form process failed");
+         console.log("Error", error);
+         dispatch(setFormProcessLoadError(true));
+         done(error);
+       });
+     }
+  };
+};
+
+/**
+ *
+ * @param  {...any} rest
+ */
+export const getProcessActivities = (process_instance_id, ...rest) => {
+  const done = rest.length ? rest[0] : () => {};
+  const apiUrlProcessActivities= replaceUrl(
+    API.PROCESS_ACTIVITIES,
+    "<process_instance_id>",
+    process_instance_id
+  );
+  return (dispatch) => {
+    httpGETRequest(
+      apiUrlProcessActivities,
+      {},
+      UserService.getToken(),
+      true
+    )
+      .then((res) => {
+        if (res.data) {
+          dispatch(setProcessActivityData(res.data.childActivityInstances));
+          dispatch(setProcessActivityLoadError(false));
+        } else {
+          dispatch(setProcessActivityData(null));
+          dispatch(setProcessActivityLoadError(true));
+        }
+        done(null,res.data);
+      })
+      .catch((error) => {
+        done(error);
+        dispatch(setProcessActivityData(null));
+        dispatch(setProcessActivityLoadError(true));
+      });
+  };
+};
+
+export const fetchDiagram = (process_key, ...rest) => {
+  const url =API.PROCESSES+'/'+process_key+'/xml';
+  const done = rest.length ? rest[0] : () => {};
+  return (dispatch) => {
+    httpGETRequest(
+      url,
+      {},
+      UserService.getToken(),
+      true
+    )
+    .then((res) => {
+      if (res.data && res.data.bpmn20Xml) {
+        dispatch(setProcessDiagramXML(res.data.bpmn20Xml));
+        // console.log('res.data.bpmn20Xml>>',res.data.bpmn20Xml);
+      } else {
+        dispatch(setProcessDiagramXML(""));
+      }
+      dispatch(setProcessDiagramLoading(false));
+      done(null,res.data);
+    })
+    .catch((error) => {
+        dispatch(setProcessDiagramXML(""));
+        dispatch(setProcessDiagramLoading(false));
+        done(error);
+      });
+  };
+};

--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -231,7 +231,6 @@ const Edit = React.memo((props) => {
   const handleChange = (path, event) => {
     const {target} = event;
     const value = target.type === 'checkbox' ? target.checked : target.value;
-    console.log("#edit-test handleChange", {path, value});
     dispatchFormAction({type: path, value});
   };
 

--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -57,7 +57,6 @@ const Edit = React.memo((props) => {
   const [form, dispatchFormAction] = useReducer(reducer, _cloneDeep(formData));
   const errors = useSelector((state) => state.form.error);
   const prviousData = useSelector((state) => state.process.formPreviousData);
-  const applicationCount = useSelector((state) =>state.process.applicationCount)
   const formProcessList = useSelector((state)=>state.process.formProcessList)
   const formPreviousData = useSelector((state)=>state.process.formPreviousData)
   const saveText = "Save Form";
@@ -94,7 +93,7 @@ const Edit = React.memo((props) => {
               id: processListData.id,
               formId: submittedData._id,
             };
-            let updated = true
+            let updated = true;
             if(isTitleChanged){
               updated= false
               data.processKey = formPreviousData.processKey
@@ -167,9 +166,9 @@ const Edit = React.memo((props) => {
   // save form data to submit
   const saveFormData = () => {
     const newFormData = addHiddenApplicationComponent(form);
-    if(prviousData.formName !== newFormData.title && applicationCount >0){
-      handleShow()
-    }else{
+    if (prviousData.formName !== newFormData.title) {
+      handleShow();
+    } else{
       newFormData.submissionAccess = SUBMISSION_ACCESS;
       newFormData.access = FORM_ACCESS;
   
@@ -192,8 +191,20 @@ const Edit = React.memo((props) => {
                 formName: submittedData.title,
                 id: processListData.id,
                 formId: submittedData._id,
-                formRevisionNumber: "V1"
+                formRevisionNumber: "V1",
               };
+              
+              // keep the existing process key and name
+              if (processListData.processKey && processListData.processName) {
+                data["processKey"]= processListData.processKey;
+                data["processName"]= processListData.processName;
+              }
+              
+              // keep the existing status
+              if (processListData.status) {
+                data["status"]= processListData.status;
+              }
+
               const updated =
                 processListData && processListData.id ? true : false;
               dispatch(saveFormProcessMapper(data, updated));
@@ -220,6 +231,7 @@ const Edit = React.memo((props) => {
   const handleChange = (path, event) => {
     const {target} = event;
     const value = target.type === 'checkbox' ? target.checked : target.value;
+    console.log("#edit-test handleChange", {path, value});
     dispatchFormAction({type: path, value});
   };
 
@@ -237,12 +249,6 @@ const Edit = React.memo((props) => {
   return (
     <div className="container">
       <div className="main-header">
-        {/* <Link to="/form">
-              <img src="/back.svg" alt="back" />
-            </Link> */}
-      {/* <span className="ml-3">
-          <img src="/form.svg" alt="Forms" />
-        </span>*/}
         <h3 className="ml-3 task-head">
           <i className="fa fa-wpforms" aria-hidden="true" /> &nbsp;{" "}
           {formData.title}

--- a/forms-flow-web/src/components/Form/Steps/PreviewStepper.js
+++ b/forms-flow-web/src/components/Form/Steps/PreviewStepper.js
@@ -1,0 +1,141 @@
+import React, {useState} from "react";
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Grid from "@material-ui/core/Grid";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import TextField from "@material-ui/core/TextField";
+import { useSelector } from "react-redux";
+
+import SaveNext from "./SaveNext";
+
+const Preview = React.memo(({
+    handleNext,
+    handleBack,
+    activeStep,
+    steps,
+    processData,
+    setProcessData,
+    workflow,
+    formData,
+    submitData,
+  }) => {
+  const [copied, setCopied] = useState(false);
+  const processListData = useSelector((state)=>state.process.formProcessList)
+  //  taking the url and make the copy button
+  const copyPublicUrl = () => {
+    const hostName = window.location.host;
+    const url = `${hostName}/public/form/${formData.form.path}`;
+    navigator.clipboard?.writeText(url).then(()=>{
+      setCopied(()=>{
+        setTimeout(()=>{
+          setCopied(false)
+        },3000)
+        return true
+      });
+    }).catch((err)=>{
+      console.log(err)
+    })
+
+  };
+
+  return (
+    <div>
+      <Grid
+        container
+        direction="row"
+        justify="flex-start"
+        alignItems="baseline"
+        spacing={3}
+      >
+        <Grid item xs={12} sm={1} spacing={3}>
+        </Grid>
+        <Grid item  xs={12} sm={8} spacing={3}/>
+        <Grid item xs={12} sm={3} className="next-btn">
+          <SaveNext
+            handleBack={handleBack}
+            handleNext={handleNext}
+            activeStep={activeStep}
+            steps={steps}
+            submitData={submitData}
+            isLastStep={true}
+          />
+        </Grid>
+        <Grid item xs={12} sm={8} spacing={3} disabled={false}>
+          <Card variant="outlined">
+            <CardContent>
+              <form noValidate autoComplete="off">
+                <div>
+                  <span className="font-weight-bolder">Form Name : </span>
+                  <span>
+                      {formData && formData.form && formData.form.title
+                        ? formData.form.title
+                        : "-"}
+                  </span>
+                </div>
+                <div>
+                  <span className="font-weight-bolder">Workflow Name : </span>
+                  <span>{workflow &&
+                  workflow.label ? workflow.label : "-"}</span>
+                </div>
+                {processListData.anonymous && (
+                  <div>
+                    <span>Copy anonymous form URL</span>
+                    <div
+                      data-toggle="tooltip"
+                      data-placement="top"
+                      title={copied ? "URL copied" : "Click Here to Copy"}
+                      className={`coursor-pointer btn ${copied?'text-success':'text-primary'}`}
+                      onClick={() => {
+                        copyPublicUrl();
+                      }}
+                    >
+                      <i className={`${copied?'fa fa-check':'fa fa-copy'}`}/>
+                    </div>
+                  </div>
+                )}
+                <div>
+                  <label>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={processData.status === "active"}
+                          onChange={(e) =>
+                            setProcessData({
+                              status: e.target.checked
+                                ? "active"
+                                : "inactive",
+                            })
+                          }
+                          name="Check box to associate form with a workflow"
+                          color="primary"
+                        />
+                      }
+                      label="Publish this form for Client Users."
+                    />
+                  </label>
+                </div>
+                <label className="text-label">Comments</label>
+                <TextField
+                  id="comments"
+                  // label="Multiline"
+                  multiline
+                  rows={4}
+                  variant="outlined"
+                  className="text-field"
+                  value={processData.comments||""}
+                  onChange={(e) =>
+                    setProcessData({
+                      comments: e.target.value,
+                    })
+                  }
+                />
+              </form>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </div>
+  );
+});
+export default Preview;

--- a/forms-flow-web/src/components/Form/Steps/SaveNext.js
+++ b/forms-flow-web/src/components/Form/Steps/SaveNext.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Button  from "@material-ui/core/Button";
+
+const SaveNext = React.memo(({ handleNext, handleBack, activeStep, isLastStep, submitData }) => {
+  return (
+    <>
+      <Button disabled={activeStep === 0} onClick={handleBack}>
+        Back
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={!isLastStep ? handleNext : submitData}
+      >
+        {isLastStep ? "Save" : "Next"}
+      </Button>
+    </>
+  );
+});
+export default SaveNext;

--- a/forms-flow-web/src/components/Form/Steps/WorkFlow.js
+++ b/forms-flow-web/src/components/Form/Steps/WorkFlow.js
@@ -1,0 +1,126 @@
+import React, { useState } from "react";
+import utils from 'formiojs/utils';
+import FormLabel from "@material-ui/core/FormLabel";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import Radio from "@material-ui/core/Radio";
+import Grid from "@material-ui/core/Grid";
+import CardContent from "@material-ui/core/CardContent";
+import Card from "@material-ui/core/Card";
+import Select from "react-dropdown-select";
+import SaveNext from "./SaveNext";
+import ProcessDiagram from "../../BPMN/ProcessDiagramHook";
+import { useSelector } from "react-redux";
+
+const WorkFlow = React.memo(({
+    associateWorkFlow,
+    changeWorkFlowStatus,
+    populateDropdown,
+    associateToWorkFlow,
+    handleNext,
+    handleBack,
+    handleEditAssociation,
+    activeStep,
+    steps,
+    workflow,
+    disableWorkflowAssociation
+}) => {
+
+  const[modified, setModified] = useState(false);
+  const { form } = useSelector((state) => state.form);
+  const componentLabel = [];
+  const ignoredTypes = ['button','columns','panel','well','container'];
+  const flattedComponent = Object.values(utils.flattenComponents(form.components, true));
+  flattedComponent.forEach(component=>{
+    if(!ignoredTypes.includes(component.type)){
+      componentLabel.push({ label: component.label, value: component.key })
+    }
+  });
+
+  return (
+    <Grid container direction="row" justify="flex-start" alignItems="baseline">
+      {/* <FormControl component="fieldset"> */}
+
+      <Grid item xs={12} sm={1} spacing={3}>
+       <button 
+        className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary" 
+        onClick={handleEditAssociation}>Edit
+       </button>
+      </Grid>
+      <Grid item xs={12} sm={8} spacing={3}/>
+      <Grid item xs={12} sm={3} className="next-btn">
+        <SaveNext
+          handleBack={handleBack}
+          handleNext={handleNext}
+          activeStep={activeStep}
+          steps={steps}
+          changeWorkFlowStatus={changeWorkFlowStatus}
+          modified={modified} 
+        />
+      </Grid>
+      <Grid item xs={12} sm={12} spacing={3}>
+        <br/>
+      </Grid>
+      <Grid item xs={12} sm={12} spacing={3} disabled={disableWorkflowAssociation}>
+        <Card variant="outlined" className="card-overflow">
+          <CardContent>
+            <Grid item xs={12} sm={12} spacing={3}>
+              <FormLabel component="legend">
+                Do you want to associate form with a workflow?
+              </FormLabel>
+              <RadioGroup
+                aria-label="associateWorkFlow"
+                name="associateWorkFlow"
+                value={associateWorkFlow}
+                onChange={(e)=>{
+                  changeWorkFlowStatus(e.target.value)}
+                }
+                row
+              >
+                <FormControlLabel
+                  value="yes"
+                  control={<Radio color="primary" />}
+                  label="Yes"
+                  />
+                <FormControlLabel
+                  value="no"
+                  control={<Radio color="primary" />}
+                  onClick={(item)=>setModified(true)}
+                  label="No"
+                />
+              </RadioGroup>
+            </Grid>
+
+            {associateWorkFlow === "yes" && (
+              <>
+                <Grid item xs={12} sm={6} spacing={3}>
+                  <h5> Please select from one of the following workflows. </h5>
+                  <Select
+                    options={populateDropdown()}
+                    onChange={(item) => {
+                      setModified(true);
+                      associateToWorkFlow(item);
+                    }}
+                    values={workflow && workflow.value ? [workflow] : []}
+                    disabled={disableWorkflowAssociation}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} spacing={3}/>
+                <br/>
+                {workflow && workflow.value && (
+                  <Grid item xs={12} spacing={3}>
+                    <ProcessDiagram
+                      process_key={workflow && workflow.value}
+                    />
+                  </Grid>
+                )}
+              </>
+            )}
+            {/* </FormControl> */}
+          </CardContent>
+        </Card>
+      </Grid>
+    </Grid>
+  );
+});
+export default WorkFlow;

--- a/forms-flow-web/src/modules/processReducer.js
+++ b/forms-flow-web/src/modules/processReducer.js
@@ -38,7 +38,7 @@ const process = (state = initialState, action) => {
     case ACTION_CONSTANTS.IS_PROCESS_DIAGRAM_LOADING:
       return { ...state, isProcessDiagramLoading: action.payload };
     case ACTION_CONSTANTS.FORM_PREVIOUS_DATA:
-      return {...state, formPreviousData:[], formPreviousData:action.payload};
+      return {...state,formPreviousData:action.payload};
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
This PR solves two issues with the current form edit process #481 . One is, the issue with the creation of a new `form-process-mapper` entry where it should be updated instead (lack of previous data caused this). Two, the issue with form losing its process and status properties during a new form upload or when a form is updated (and not process and status).

## Changes
- process reducer and service are updated to get previous form data (this was missing in my public form pr 😅 ). This prevents the creation of unnecessary `form-process-mapper` entries in the database, instead, that field will be updated appropriately.
- In case only form and not a process are updated/edited, existing process and status are kept (this was a bug in form-flow-ai even in the latest version). This prevents losing the form's process and status, when a new form (with the same name) is uploaded into the system or the form alone, is updated.
- Form stepper-related codes were updated to integrate some of the new changes in v4.0.5. This will make it easier to upgrade to the new version in the future.