### PR TITLE
form-process-mapper returns only the first record in db to fix the is…

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from http import HTTPStatus
 
-from sqlalchemy import UniqueConstraint, and_, desc
+from sqlalchemy import UniqueConstraint, and_, desc, asc
 from sqlalchemy.dialects.postgresql import JSON
 from formsflow_api.exceptions import BusinessException
 from formsflow_api.models.audit_mixin import AuditDateTimeMixin, AuditUserMixin
@@ -142,9 +142,9 @@ class FormProcessMapper(AuditDateTimeMixin, AuditUserMixin, BaseModel, db.Model)
             cls.query.filter(
                 FormProcessMapper.form_id == form_id,
             )
+            .order_by(asc(FormProcessMapper.id))
             .limit(1)
             .first()
-            # .order_by(desc(FormProcessMapper.version))
         )  # pylint: disable=no-member
 
     @classmethod

--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -200,10 +200,6 @@ const Edit = React.memo((props) => {
                 data["processName"]= processListData.processName;
               }
               
-              // keep the existing status
-              if (processListData.status) {
-                data["status"]= processListData.status;
-              }
 
               const updated =
                 processListData && processListData.id ? true : false;


### PR DESCRIPTION
## Summary
This PR fixes the issue of `form-process-mapper` leakage. As reported in #481

## Background:
There was an issue that in some cases during the editing a form by a designer, a new form-process-mapper was created in the DB instead of updating the one designer changed.

Next time the designer wants to edit a form, since there are multiple entries of `form-process-mapper` in DB, another one, different from the one last time was changed, was loaded, giving the designer the impression that previous changes were not saved properly, which in fact it was saved to another `form-process-mapper`.

## FIX
This PR guarantees that only the first item in the DB is returned every time a `form-process-mapper` is fetched by `form-id`. This means the designer will always work with the same entry and changes will be properly saved.



## Note

- The actual issue of leakage was fixed in [this PR](https://github.com/bcgov/digital-journeys/pull/486)
- In the next version of the form-flow-ai, form-process-mapper will be saved as a separate entry with each change with a new version. The latest version of that mapper will be loaded. Before that this pr will fix our issues.

