### PR TITLE
DGJ-483 Reduce number of pds that can be generated in parallel

### DIFF
--- a/formio-upload/pdf-generation/generatePdf.js
+++ b/formio-upload/pdf-generation/generatePdf.js
@@ -28,8 +28,8 @@ const externalStyles = [
 // Pool of puppeteer browsers to choose from
 const browserPool = new BrowserPool({
   browserPlugins: [new PuppeteerPlugin(puppeteer, {
-    maxOpenPagesPerBrowser: 10,
-    retireBrowserAfterPageCount: 75,
+    maxOpenPagesPerBrowser: 3,
+    retireBrowserAfterPageCount: 50,
     launchOptions: {
       headless: true,
       args: ['--no-sandbox']


### PR DESCRIPTION
## Summary

Reduced the number of pds that can be generated in parallel, to avoid the service hitting its resource limits.
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Restrict number of pdfs to be generated in parallel to 3
- Recycle browser more often to reduce chance of memory leaks
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->