### PR TITLE
Recreate image change triggers for automated deployments in openshift

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -274,6 +274,15 @@ objects:
       test: false
       triggers:
       - type: ConfigChange
+      - imageChangeParams:
+          automatic: true
+          containerNames:
+          - ${NAME}
+          from:
+            kind: ImageStreamTag
+            namespace: "${TOOLS_WORKSPACE}"
+            name: "${NAME}:${IMAGE_TAG}"
+        type: ImageChange
 
 parameters:
   - name: NAME

--- a/deployment/openshift/web_dc.yaml
+++ b/deployment/openshift/web_dc.yaml
@@ -68,6 +68,15 @@ objects:
       test: false
       triggers:
         - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              namespace: "${IMAGE_NAMESPACE}"
+              name: "${NAME}:${TAG_NAME}"
+          type: ImageChange
     status: {}
 
   -

--- a/deployment/openshift/webapi_dc.yaml
+++ b/deployment/openshift/webapi_dc.yaml
@@ -153,6 +153,15 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME}
+        from:
+          kind: ImageStreamTag
+          namespace: "${IMAGE_NAMESPACE}"
+          name: "${NAME}:${TAG_NAME}"
+      type: ImageChange
   status: {}
 
 -


### PR DESCRIPTION
## Summary

Recreate image change triggers for auto deplpyments in openshift

## Changes
Changed templates for camunda, web and api to rebuild imagechange triggers


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->