### PR TITLE
Added daily backup trigger for forms-flow-files PVC

### DIFF
--- a/.github/workflows/form-flow-files-backup.yaml
+++ b/.github/workflows/form-flow-files-backup.yaml
@@ -1,0 +1,40 @@
+name: Run file backups for forms-flow-files
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  fileBackup:
+    name: Trigger file backups
+    strategy:
+      fail-fast: false
+      #Run file backups for multiple environments
+      matrix:
+        namespace: [d89793-dev, d89793-test, d89793-prod]
+    runs-on: ubuntu-latest
+    env:
+      APP: forms-flow-files
+      NO_OF_DAYS: +7
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+      - name: Run file backups
+        run: |
+          oc project ${{ matrix.namespace }}
+          echo "Current namespace is ${{ matrix.namespace }}"
+          podNames=$(oc get pods -l deploymentconfig=${APP} --field-selector=status.phase=Running -o name)
+          echo $podNames
+          
+          #Backup ${APP} to a backup PVC pointing to /tmp/file-backups
+          #Purge backups older than NO_OF_DAYS to reclaim space
+          for name in $podNames; do
+            oc exec $name -- bash -c "
+              mkdir -p /tmp/file-backups && \
+              find /tmp/file-backups/ -maxdepth 1 -mtime ${NO_OF_DAYS} -type d -exec rm -r  {} \; && \
+              echo 'PROJECT NAMESPACE is: '  ${{ matrix.namespace }} && \
+              rsync -rz /uploads/ /tmp/file-backups/filedir-${{ matrix.namespace }}-$(date "+%Y.%m.%d-%H.%M.%S") && \
+              "
+          done

--- a/.github/workflows/form-flow-files-backup.yaml
+++ b/.github/workflows/form-flow-files-backup.yaml
@@ -2,7 +2,7 @@ name: Run file backups for forms-flow-files
 
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '12 14 * * *'
 
 jobs:
   fileBackup:
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       #Run file backups for multiple environments
       matrix:
-        namespace: [d89793-dev, d89793-test, d89793-prod]
+        namespace: [d89793-dev]
     runs-on: ubuntu-latest
     env:
       APP: forms-flow-files
-      NO_OF_DAYS: +7
+      NO_OF_DAYS: +5
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
         run: |
           oc project ${{ matrix.namespace }}
           echo "Current namespace is ${{ matrix.namespace }}"
-          podNames=$(oc get pods -l deploymentconfig=${APP} --field-selector=status.phase=Running -o name)
+          podNames=$(oc get pods -l app=${APP} --field-selector=status.phase=Running -o name)
           echo $podNames
           
           #Backup ${APP} to a backup PVC pointing to /tmp/file-backups
@@ -35,6 +35,6 @@ jobs:
               mkdir -p /tmp/file-backups && \
               find /tmp/file-backups/ -maxdepth 1 -mtime ${NO_OF_DAYS} -type d -exec rm -r  {} \; && \
               echo 'PROJECT NAMESPACE is: '  ${{ matrix.namespace }} && \
-              rsync -rz /uploads/ /tmp/file-backups/filedir-${{ matrix.namespace }}-$(date "+%Y.%m.%d-%H.%M.%S") && \
+              rsync -rz /uploads/ /tmp/file-backups/uploads-${{ matrix.namespace }}-$(date "+%Y.%m.%d-%H.%M.%S") && \
               "
           done


### PR DESCRIPTION
## Summary

- Added github workflow cron trigger to backup form-flow-files PVC
  - Schedule - Daily at 9am
  - Source: forms-flow-files pvc
  - destination: forms-flow-files-backup

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->