### PR TITLE
fix redundant backup for forms-files-flow when multiple pods

### DIFF
--- a/.github/workflows/form-flow-files-backup.yaml
+++ b/.github/workflows/form-flow-files-backup.yaml
@@ -32,10 +32,9 @@ jobs:
           
           #Backup ${APP} to a backup PVC pointing to /tmp/file-backups
           #Purge backups older than NO_OF_DAYS to reclaim space
-          for name in $podNames; do
-            oc exec $name -- sh -c """
-              mkdir -p /tmp/file-backups && \
-              find /tmp/file-backups/ -maxdepth 1 -mtime ${NO_OF_DAYS} -type d -exec rm -r  {} \; && \
-              echo 'PROJECT NAMESPACE is: '  ${{ matrix.namespace }} && \
-              rsync -rz /uploads/ /tmp/file-backups/uploads-${{ matrix.namespace }}-$(date "+%Y.%m.%d-%H.%M.%S")"""
-          done
+          # Only Exec into one pod, and place the backups in the shared and mounted backup PVC
+          oc exec ${podNames[0]} -- sh -c """
+            mkdir -p /tmp/file-backups && \
+            find /tmp/file-backups/ -maxdepth 1 -mtime ${NO_OF_DAYS} -type d -exec rm -r  {} \; && \
+            echo 'PROJECT NAMESPACE is: '  ${{ matrix.namespace }} && \
+            rsync -rz /uploads/ /tmp/file-backups/uploads-${{ matrix.namespace }}-$(date "+%Y.%m.%d-%H.%M.%S")"""


### PR DESCRIPTION
## Summary

Problem: There were redundant backups getting created when multiple pods running.

<img width="753" alt="image" src="https://user-images.githubusercontent.com/87394256/185652371-fdb62e27-5307-4bfd-bb4d-f7657b266a73.png">

Fix: removed unnecessary loop

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->