### PR TITLE
scroll to validation error field was added to form edit, form edit pa…

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -52,9 +52,9 @@ const Edit = React.memo((props) => {
 
   let scrollToErrorInterval = null;
   useEffect(() => {
-      scrollToErrorInterval = setInterval(() => {
-        scrollToErrorOnValidation()
-      }, 1000);
+    scrollToErrorInterval = setInterval(() => {
+      scrollToErrorOnValidation()
+    }, 1000);
     return () => {
       clearInterval(scrollToErrorInterval);
     }

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {connect, useDispatch, useSelector} from 'react-redux'
 import { selectRoot, resetSubmissions, saveSubmission, Form, selectError, Errors } from 'react-formio';
 import { push } from 'connected-react-router';
@@ -34,6 +34,7 @@ const Edit = React.memo((props) => {
     form: { form, isActive: isFormActive },
     submission: { submission, isActive: isSubActive, url },
   } = props;
+  const formRef = useRef(null);
   
   const applicationStatus = useSelector(state => state.applications.applicationDetail?.applicationStatus || '');
   const userRoles = useSelector((state) => {
@@ -49,6 +50,16 @@ const Edit = React.memo((props) => {
     }
   }, [applicationStatus, userRoles, dispatch, submissionId, formId, onFormSubmit ]);
 
+  let scrollToErrorInterval = null;
+  useEffect(() => {
+      scrollToErrorInterval = setInterval(() => {
+        scrollToErrorOnValidation()
+      }, 1000);
+    return () => {
+      clearInterval(scrollToErrorInterval);
+    }
+  });
+  
   if ((isFormActive ||  (isSubActive && !isFormSubmissionLoading))) {
       return <Loading />;
   }
@@ -64,6 +75,22 @@ const Edit = React.memo((props) => {
         }
     }, submission);
   
+  const scrollToErrorOnValidation = () => {
+    const formio = formRef.current?.formio;
+    if (formio) {
+      clearInterval(scrollToErrorInterval);
+      formio.on('checkValidity', (_) => {
+        const componentsWithErrors = [];
+        formio.everyComponent((component) => {
+          if (component.error) {
+            componentsWithErrors.push(component);
+          }
+        });
+        componentsWithErrors[0]?.scrollIntoView();
+      });
+    }
+  };
+  
   return (
       <div className="container">
         <div className="main-header">
@@ -78,6 +105,7 @@ const Edit = React.memo((props) => {
         <LoadingOverlay active={isFormSubmissionLoading} spinner text='Loading...' className="col-12">
           <div className="ml-4 mr-4">
         <Form
+          ref={formRef}
           form={form}
           submission={submissionWithTask}
           url={url}

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -791,6 +791,12 @@ fieldset {
 }
 // --END--- Style to enable scrollbar on the form -----
 
+// Enable proper page scrolling on the /task/:formId (formEdit) page
+.service-task-details {
+  max-height: none !important;
+  overflow-y: hidden !important;
+}
+
 .form-group fieldset {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
This PR fixes the issue with the validation error that was not scrolled to during the supervisor/manager signoff. The problem was described in #468 


## Changes
- CSS rules were added to the global style to fix the issue with two scrollbars on form edit submission page (for example in the Telework form, the page where the supervisor signs off the form)
- Reference to formio instance was added in Edit submission page to listen and find the validation errors
- Logic to scroll to the top most form field with validation error was added

## Notes
Please note that the formio instance has only become available after a certain amount of time. As a workaround, I added an interval to check for the formio instance every 1000 ms with cleaning logic. Please let me know if there is a better/cleaner way to handle this.