### PR TITLE
Replace "ADM" with "ADM (or delegate)" in the Telework agreement form

### DIFF
--- a/forms-flow-bpm/processes/telework-form-html-email-test.bpmn
+++ b/forms-flow-bpm/processes/telework-form-html-email-test.bpmn
@@ -27,7 +27,7 @@ For your review, please find attached a new Telework Agreement submitted by ${su
 Go to the Manager/Supervisor Sign-Off Section at $BASE_URL/task/$TASK_ID to complete and submit this form.
 
 
-*If this Telework request is for 3 days or more, you must get approval from your ADM or delegate.
+*If this Telework request is for 3 days or more, you must get approval from your ADM (or delegate).
 
 
 Thank you</camunda:expression>
@@ -190,7 +190,7 @@ execution.setVariable('applicationStatus','New');</camunda:script>
     <bpmn:sequenceFlow id="Flow_07pivsl" sourceRef="Activity_0udx9dh" targetRef="Gateway_1gqg4sz" />
     <bpmn:sequenceFlow id="Flow_107tioi" sourceRef="Gateway_1gqg4sz" targetRef="send_to_ods" />
     <bpmn:textAnnotation id="TextAnnotation_1vplb42">
-      <bpmn:text>Attached Uploaded ADM Approval Record if required</bpmn:text>
+      <bpmn:text>Attached Uploaded ADM (or delegate) Approval Record if required</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1tytyjh" sourceRef="Activity_0udx9dh" targetRef="TextAnnotation_1vplb42" />
     <bpmn:textAnnotation id="TextAnnotation_10vy6xw">

--- a/forms-flow-bpm/processes/telework-form.bpmn
+++ b/forms-flow-bpm/processes/telework-form.bpmn
@@ -719,17 +719,17 @@ task.execution.setVariable('managersSignatureTimestamp', new Date().toISOString(
         <camunda:inputOutput>
           <camunda:inputParameter name="body">&lt;p&gt;A new telework agreement request has been submitted by ${name} (${email}) requesting ${numberOfDaysTeleworkingInAWeek} weekly telework days. &lt;/p&gt;
 &lt;br&gt;
-&lt;strong&gt;This request requires ADM approval.&lt;/strong&gt;
+&lt;strong&gt;This request requires ADM (or delegate) approval.&lt;/strong&gt;
 &lt;ul&gt;
-&lt;li&gt;Please review the attached PDF and address any issues with ${name} before requesting ADM approval and use it to discuss this case with your ADM.&lt;/li&gt;
+&lt;li&gt;Please review the attached PDF and address any issues with ${name} before requesting ADM (or delegate) approval and use it to discuss this case with your ADM (or delegate).&lt;/li&gt;
 &lt;/ul&gt; 
 &lt;br&gt;
-&lt;strong&gt;After obtaining proof of ADM approval:&lt;/strong&gt;
+&lt;strong&gt;After obtaining proof of ADM (or delegate) approval:&lt;/strong&gt;
 &lt;ul&gt;
 &lt;li&gt;Open the request at this link: $BASE_URL/task/$TASK_ID &lt;/li&gt;
 &lt;li&gt;Complete the supervisor sign-off section of the agreement &lt;/li&gt;
-&lt;li&gt;Upload proof of ADM approval&lt;/li&gt; 
-&lt;li&gt;Supported file types for ADM approval are:&lt;/li&gt;
+&lt;li&gt;Upload proof of ADM (or delegate) approval&lt;/li&gt; 
+&lt;li&gt;Supported file types for ADM (or delegate) approval are:&lt;/li&gt;
 &lt;ul&gt;
 &lt;li&gt;.eml (saved email file)&lt;/li&gt;
 &lt;li&gt;.msg (saved outlook email file)&lt;/li&gt;
@@ -801,7 +801,7 @@ For questions or feedback about the Telework agreement or other PSA forms, pleas
       <bpmn:outgoing>Flow_0ptyhn1</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:textAnnotation id="TextAnnotation_1teg9e6">
-      <bpmn:text>Attached Uploaded ADM Approval Record if required</bpmn:text>
+      <bpmn:text>Attached Uploaded ADM (or delegate) Approval Record if required</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:textAnnotation id="TextAnnotation_1dpmopj">
       <bpmn:text>Sends Email to Manager when task is created</bpmn:text>
@@ -815,7 +815,7 @@ For questions or feedback about the Telework agreement or other PSA forms, pleas
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1q6nu2g" sourceRef="TextAnnotation_0n8lxvh" targetRef="Gateway_1h5f4rh" />
     <bpmn:textAnnotation id="TextAnnotation_0w9ivj6">
-      <bpmn:text>Attached Uploaded ADM Approval Record if required</bpmn:text>
+      <bpmn:text>Attached Uploaded ADM (or delegate) Approval Record if required</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:textAnnotation id="TextAnnotation_1rj0ujt">
       <bpmn:text>Sends Email to Manager when task is created</bpmn:text>

--- a/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
@@ -52,7 +52,7 @@ export default React.memo(() => {
             <ul>
               <li>The employee has been notified by email of your decision and has received a pdf copy of the completed telework agreement.</li>
 
-              <li>You will receive by email a pdf copy of the Telework Agreement, as well as an attachment with ADM approval if the request was for three or more Telework days.</li>
+              <li>You will receive by email a pdf copy of the Telework Agreement, as well as an attachment with ADM (or delegate) approval if the request was for three or more Telework days.</li>
 
               <li>The attachments can be stored in your personnel files or according to your ministry's record-keeping policy.</li>
 


### PR DESCRIPTION
## Summary

This PR replaces "ADM" with "ADM (or delegate)" in the Telework Agreement form. 

## Changes

Changes were made in 
- Workflow files (.bpmn) that reflect changes in the workflow process.
- Approval HTML page (.js file)
- In the form major title were updated, but Only a couple of places remain, That has been updated on the Dev environment.



## Notes

Changes have been applied to the form(Available in the dev environment),
Process/Flow, notification template, and approval page content will be updated using this PR.
