### PR TITLE
base html element was added to open all the link in a new tab

### DIFF
--- a/forms-flow-web/public/index.html
+++ b/forms-flow-web/public/index.html
@@ -16,6 +16,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <title>Digital Journeys</title>
+    <base target="_blank">
   </head>
   <body class="no-scroll">
     <div id="app" class="scrollable-page"></div>


### PR DESCRIPTION
## Summary

This PR will force all the `<href>` tags to open in a new tab as requested in #491 

## Changes
- A `<base>` tag was added to the `header` of the topmost index overwriting all the `<href>` tags to open in new tabs.
