### PR TITLE
making the form links open in a new tabs

### DIFF
--- a/forms-flow-web/public/index.html
+++ b/forms-flow-web/public/index.html
@@ -16,7 +16,6 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <title>Digital Journeys</title>
-    <base target="_blank">
   </head>
   <body class="no-scroll">
     <div id="app" class="scrollable-page"></div>

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -19,6 +19,11 @@ import {updateApplicationEvent} from "../../../../../apiManager/services/applica
 import LoadingOverlay from "react-loading-overlay";
 import {toast} from "react-toastify";
 import _ from 'lodash';
+import {
+  convertFormLinksToOpenInNewTabs,
+  scrollToErrorOnValidation,
+} from "../../../../../helper/formUtils";
+
 const Edit = React.memo((props) => {
   const dispatch = useDispatch();
   const {formId, submissionId} = useParams();
@@ -53,10 +58,23 @@ const Edit = React.memo((props) => {
   let scrollToErrorInterval = null;
   useEffect(() => {
     scrollToErrorInterval = setInterval(() => {
-      scrollToErrorOnValidation()
+      scrollToErrorOnValidation(formRef.current?.formio, scrollToErrorInterval);
     }, 1000);
     return () => {
       clearInterval(scrollToErrorInterval);
+    }
+  });
+  
+  let convertFormLinksInterval = null;
+  useEffect(() => {
+    convertFormLinksInterval = setInterval(() => {
+      convertFormLinksToOpenInNewTabs(
+        formRef.current?.formio,
+        convertFormLinksInterval
+      );
+    }, 1000);
+    return () => {
+      clearInterval(convertFormLinksInterval);
     }
   });
   
@@ -74,22 +92,6 @@ const Edit = React.memo((props) => {
             }
         }
     }, submission);
-  
-  const scrollToErrorOnValidation = () => {
-    const formio = formRef.current?.formio;
-    if (formio) {
-      clearInterval(scrollToErrorInterval);
-      formio.on('checkValidity', (_) => {
-        const componentsWithErrors = [];
-        formio.everyComponent((component) => {
-          if (component.error) {
-            componentsWithErrors.push(component);
-          }
-        });
-        componentsWithErrors[0]?.scrollIntoView();
-      });
-    }
-  };
   
   return (
       <div className="container">

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState} from "react";
+import React, { useCallback, useEffect, useState, useRef} from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
 import {
   selectRoot,
@@ -39,7 +39,8 @@ import {checkIsObjectId} from "../../../apiManager/services/formatterService";
 import { setPublicStatusLoading } from "../../../actions/applicationActions";
 
 import {fetchEmployeeData} from "../../../apiManager/services/employeeDataService";
-import { exportToPdf } from '../../../services/PdfService'
+import { exportToPdf } from '../../../services/PdfService';
+import { convertFormLinksToOpenInNewTabs } from "../../../helper/formUtils";
 
 const View = React.memo((props) => {
   const isFormSubmissionLoading = useSelector(
@@ -71,6 +72,7 @@ const View = React.memo((props) => {
     getEmployeeData,
     employeeData,
   } = props;
+  const formRef = useRef(null);
   const dispatch = useDispatch();
 
   const getPublicForm = useCallback((form_id, isObjectId, formObj) => {
@@ -137,6 +139,19 @@ const View = React.memo((props) => {
     dispatch(setMaintainBPMFormPagination(true));
 
   }, [getForm, getEmployeeData, isAuthenticated, dispatch]);
+
+  let convertFormLinksInterval = null;
+  useEffect(() => {
+    convertFormLinksInterval = setInterval(() => {
+      convertFormLinksToOpenInNewTabs(
+        formRef.current?.formio,
+        convertFormLinksInterval
+      );
+    }, 1000);
+    return () => {
+      clearInterval(convertFormLinksInterval);
+    };
+  });
 
   if (isActive || isPublicStatusLoading) {
     return (
@@ -261,6 +276,7 @@ const View = React.memo((props) => {
         </div>
         <div className='ml-4 mr-4' id='formview'>
           <Form
+            ref={formRef}
             form={form}
             submission={getDefaultValues(employeeData.data)}
             url={url}

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -1,0 +1,31 @@
+const convertFormLinksToOpenInNewTabs = (formio, convertFormLinksInterval) => {
+  if (formio) {
+    clearInterval(convertFormLinksInterval);
+    formio.everyComponent((component) => {
+      if (component.component.html) {
+        component.component.html = component.component.html.replace(
+          /<a\s+href=/gi,
+          '<a target="_blank" href='
+        );
+        formio.redraw();
+      }
+    });
+  }
+};
+
+const scrollToErrorOnValidation = (formio, scrollToErrorInterval) => {
+  if (formio) {
+    clearInterval(scrollToErrorInterval);
+    formio.on("checkValidity", (_) => {
+      const componentsWithErrors = [];
+      formio.everyComponent((component) => {
+        if (component.error) {
+          componentsWithErrors.push(component);
+        }
+      });
+      componentsWithErrors[0]?.scrollIntoView();
+    });
+  }
+};
+
+export { convertFormLinksToOpenInNewTabs, scrollToErrorOnValidation };


### PR DESCRIPTION
## Summary

This PR removes the global `<base>` tag that makes all the `<href>` tags in the app open in new tabs and instead, add that attribute (`target="_blank"`) only to form components with an `<href>` tag. #491 

## Changes
- Remove the global `base` tag
- Add a form util function that read through the form components and make the links open in new tabs
- Refactored the form util functions that rely on formio object in a separate module.