### PR TITLE
collapsible icon color was changed

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -151,6 +151,10 @@ i.fa.fa-question-circle.text-muted {
   color: #2e96ff !important;
 }
 
+i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
+  color: #ffffff !important;
+}
+
 .panel-heading {
   background-color: $blueBackgroundColor;
   border: $blueBackgroundColor;


### PR DESCRIPTION
## Summary

This PR improves the contrast of the collapsible button as part of ticket #541 

## Changes
- Color of the plus and minus icons was changed to white.

## Screenshots (if applicable)
<img width="560" alt="Screen Shot 2022-09-06 at 4 36 55 PM" src="https://user-images.githubusercontent.com/77303486/188758255-bc18479e-eafb-4534-afa6-4a7a6da4e6b5.png">

