### PR TITLE
DGJ-567 Re-generate iat of formio temp tokens

### DIFF
--- a/forms-flow-forms/src/authentication/index.js
+++ b/forms-flow-forms/src/authentication/index.js
@@ -151,6 +151,10 @@ module.exports = (router) => {
 
     // Delete the previous expiration so we can generate a new one.
     delete tempToken.exp;
+
+    // Delete the previous iat so we can generate a new one. This to prevent generating tokens
+    // that has already expired.
+    delete tempToken.iat;
      
     // Sign the token.
     jwt.sign(tempToken,process.env.FORMIO_JWT_SECRET||jwtConfig.secret, {


### PR DESCRIPTION
## Summary
Fixes an issue where temporary auth tokens generated by Formio does not have the expected expiry date. Source of issue: The expiry date of the new token was calculated as a time (3600s by default) after the `iat` of the source token instead of after the current time. This can cause the new temporary token to already be expired, which would cause a 401 if used - which is the cause of the issues reported around emails with attachments sometimes failing. 

Fix: Make sure a new `iat` is generated when generating the temporary token

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->