### PR TITLE
date fields minDate validation were removed before pdf server generation

### DIFF
--- a/formio-upload/pdf-generation/formUtils.js
+++ b/formio-upload/pdf-generation/formUtils.js
@@ -1,0 +1,28 @@
+/*
+* A recursively lookup in all form components and set the target value
+* for the target property with the specified key
+*/
+function setValueForEveryComponentByKey({
+  components,
+  targetKey,
+  targetValue,
+}) {
+  const fnd = (obj) => {
+    if (!obj || Object.entries(obj).length === 0) {
+      return;
+    }
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === targetKey && v !== null) {
+        obj[k] = targetValue;
+      }
+      if (typeof v === "object") {
+        fnd(v);
+      }
+    }
+  };
+  fnd(components);
+}
+
+module.exports = {
+  setValueForEveryComponentByKey,
+};

--- a/formio-upload/pdf-generation/generatePdf.js
+++ b/formio-upload/pdf-generation/generatePdf.js
@@ -1,40 +1,42 @@
-const url = require('url');
-const debug = require('debug');
-const log = debug('pdfGeneration');
+const url = require("url");
+const debug = require("debug");
+const log = debug("pdfGeneration");
 
-const { BrowserPool, PuppeteerPlugin } = require('browser-pool');
-const puppeteer = require('puppeteer');
+const { BrowserPool, PuppeteerPlugin } = require("browser-pool");
+const puppeteer = require("puppeteer");
+
+const { setValueForEveryComponentByKey } = require("./formUtils");
 
 /**
  * Local scripts to embed onto the page.
  * These are added by Puppeteer to avoid extra network requests
  */
-const externalScripts = [
-  'pdf-generation/scripts/formio-4.13.1.full.min.js',
-];
+const externalScripts = ["pdf-generation/scripts/formio-4.13.1.full.min.js"];
 
 /**
  * Local styles to embed onto the page.
  * These are added by Puppeteer to avoid extra network requests
  */
 const externalStyles = [
-  'pdf-generation/styles/bootstrap-4.1.3.min.css',
-  'pdf-generation/styles/font-awesome-4.7.0.min.css',
-  'pdf-generation/styles/formio-4.13.1.full.min.css',
-  'pdf-generation/styles/semantic-2.4.1.min.css',
-  'pdf-generation/styles/digital-journeys-0-1-0-min.css',
-]
+  "pdf-generation/styles/bootstrap-4.1.3.min.css",
+  "pdf-generation/styles/font-awesome-4.7.0.min.css",
+  "pdf-generation/styles/formio-4.13.1.full.min.css",
+  "pdf-generation/styles/semantic-2.4.1.min.css",
+  "pdf-generation/styles/digital-journeys-0-1-0-min.css",
+];
 
 // Pool of puppeteer browsers to choose from
 const browserPool = new BrowserPool({
-  browserPlugins: [new PuppeteerPlugin(puppeteer, {
-    maxOpenPagesPerBrowser: 3,
-    retireBrowserAfterPageCount: 50,
-    launchOptions: {
-      headless: true,
-      args: ['--no-sandbox']
-    }
-  })],
+  browserPlugins: [
+    new PuppeteerPlugin(puppeteer, {
+      maxOpenPagesPerBrowser: 3,
+      retireBrowserAfterPageCount: 50,
+      launchOptions: {
+        headless: true,
+        args: ["--no-sandbox"],
+      },
+    }),
+  ],
 });
 
 /**
@@ -47,52 +49,67 @@ module.exports = async function generatePdf(formData, submissionData) {
   let page = null;
   try {
     page = await browserPool.newPage();
-    page.on('pageerror', ({ message }) => log(message))
+    page.on("pageerror", ({ message }) => log(message));
 
     page.setViewport({
       width: 1024,
-      height: 1070
+      height: 1070,
     });
 
     await loadFormioPage(page);
 
+    /*
+     * Removing minDate validations for date fields to disable
+     * those validations and let the date values pass to the form fields.
+     */
+    setValueForEveryComponentByKey({
+      components: formData.components,
+      targetKey: "minDate",
+      targetValue: null,
+    });
+
     // Render the given Formio submission
-    await page.evaluate(async (formData, submissionData, viewportHeight) => {
-      await window.createForm(formData, submissionData, viewportHeight);
-    }, formData, submissionData, 600);
-    
+    await page.evaluate(
+      async (formData, submissionData, viewportHeight) => {
+        await window.createForm(formData, submissionData, viewportHeight);
+      },
+      formData,
+      submissionData,
+      600
+    );
+
     // Wait for the submission to finish rendering
-    await page.waitForSelector('#formio-form-rendered');
+    await page.waitForSelector("#formio-form-rendered");
 
     // Export pdf using `html2pdf.js` - this returns the pdf as a byte string.
     // This is used in place of the built in puppeteer pdf functionality as it
     // handles page breaks in a gracefuly way that works seamlessly with Formio forms.
 
     const pdf = await page.pdf({
-        format: 'letter',
-        printBackground: true,
-        margin: {
-          top: '60px',
-          right: '0px',
-          bottom: '64px',
-          left: '0px'
+      format: "letter",
+      printBackground: true,
+      margin: {
+        top: "60px",
+        right: "0px",
+        bottom: "64px",
+        left: "0px",
       },
     });
-    
-    return pdf.toString('binary');
+
+    return pdf.toString("binary");
   } finally {
-    if(page) {
+    if (page) {
       await page.close();
     }
   }
-}
+};
 
 /**
  * Opens the formio html through a file url
  * and adds the internal script tags and styles to the page
  */
 async function loadFormioPage(page) {
-  await page.goto(url.pathToFileURL('./pdf-generation/formio.html'));
+  await page.goto(url.pathToFileURL("./pdf-generation/formio.html"));
 
   for (const path of externalScripts) {
     await page.addScriptTag({ path });


### PR DESCRIPTION
## Summary (ticket #568)

This PR will fix the issue with the date field of the generated PDF files that were rendered empty when a supervisor signed off a submission one or more days after the original employee submission.

## Changes
- A function was added to remove the `mindDate` of date fields before the form object is sent to the pdf is generated.
- Formatted the generate file to look nicer :)



## Notes
I tried different approaches to disable the date validation such as making those fields `readOnly`, similar to what I did on the web form, and also various ways to use formio built-in functions --in the form generation HTML, but none worked. Finally, changed the form object before it passed to the PDF generation script in Puppeteer.