### PR TITLE
web docker files were updated - form validation render issue was fixed

### DIFF
--- a/forms-flow-web/Dockerfile
+++ b/forms-flow-web/Dockerfile
@@ -8,18 +8,11 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh lsyncd
-COPY /public/logo.svg /app/public/
 
-# ARG CUSTOM_SRC_DIR=src
-# ARG FORMS_FLOW_WEB_UTIL_DIR=forms-flow-util
-# Override these files they have custom changes in the sbc_divapps directory
-# COPY ./${CUSTOM_SRC_DIR}/  /app/${CUSTOM_SRC_DIR}/
-# COPY ./${FORMS_FLOW_WEB_UTIL_DIR}/  /app/${FORMS_FLOW_WEB_UTIL_DIR}/
+# install and cache app dependencies
 
-# ARG CUSTOM_SVG_DIR=public/webfonts
-COPY ./public/webfonts/ /app/public/webfonts/
-
-COPY ./package*.json ./
+COPY package-lock.json /app/package-lock.json
+COPY package.json /app/package.json
 
 RUN npm install
 

--- a/forms-flow-web/Dockerfile.prod
+++ b/forms-flow-web/Dockerfile.prod
@@ -1,7 +1,3 @@
-# Used as a reference for any custom logic to be done.
-# if the application is built from a source repo other than aot , use the custom copying.
-# steps : checkout the aot source code and use the copy logic.
-# -----------------------------------------------------------
 # base image
 FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.20.0-alpine as build-stage
 
@@ -11,8 +7,6 @@ WORKDIR /app
 # add `/app/node_modules/.bin` to $PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
-# COPY . /digital-journeys/
-
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
@@ -21,13 +15,7 @@ RUN apk update && apk upgrade && \
 COPY package-lock.json /app/package-lock.json
 COPY package.json /app/package.json
 
-# Apply changes from digital-journeys on top of the formsflow.ai source code
-# RUN cp -rf /digital-journeys/* /app/
-
-# RUN rm /app/public/formsflow.ai_icon.svg
-COPY /public/logo.svg /app/public/
-
-RUN npm install --unsafe-perm --production
+RUN npm install
 COPY . /app/
 RUN npm run build
 

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -7,7 +7,6 @@ const convertFormLinksToOpenInNewTabs = (formio, convertFormLinksInterval) => {
           /<a\s+href=/gi,
           '<a target="_blank" href='
         );
-        formio.redraw();
       }
     });
   }


### PR DESCRIPTION
## Summary

This PR fixes two issues, One, the issue with the web app docker build in production and two, it fixed the issue in validation errors toggle on/off due to formio redraw in `convertFormLinksToOpenInNewTabs` function, which is no longer needed in v5.


## Changes
- The web local docker file was updated
- The web prod docker file was updated
- Formio redraw was removed in `convertFormLinksToOpenInNewTabs`
