### PR TITLE
DGJ-640 add Print as PDF button on Draft, Application and Task tabs

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -41,6 +41,7 @@ import Loading from "../../containers/Loading";
 import SubmissionError from "../../containers/SubmissionError";
 import SavingLoading from "../Loading/SavingLoading";
 import { redirectToFormSuccessPage } from "../../constants/successTypes";
+import PrintPDF from "../../helper/PrintPDF";
 
 const View = React.memo((props) => {
   const { t } = useTranslation();
@@ -193,7 +194,8 @@ const View = React.memo((props) => {
         text={<Translation>{(t) => t("Loading...")}</Translation>}
         className="col-12"
       >
-        <div className="ml-4 mr-4">
+        <PrintPDF />
+        <div className="ml-4 mr-4" id="formview">
           {
             <Form
               form={form}

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -54,6 +54,7 @@ import {
 import { getTaskSubmitFormReq } from "../../../../../apiManager/services/bpmServices";
 import { redirectToSuccessPage } from "../../../../../constants/successTypes";
 import { CUSTOM_EVENT_TYPE } from "../../../../ServiceFlow/constants/customEventTypes";
+import PrintPDF from "../../../../../helper/PrintPDF";
 
 const Edit = React.memo((props) => {
   const { t } = useTranslation();
@@ -231,7 +232,8 @@ const Edit = React.memo((props) => {
         text={t("Loading...")}
         className="col-12"
       >
-        <div className="ml-4 mr-4">
+        <PrintPDF />
+        <div className="ml-4 mr-4" id="formview">
           <Form
             form={form}
             // submission={updatedSubmission}

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
@@ -83,7 +83,7 @@ const View = React.memo((props) => {
         text={t("Loading...")}
         className="col-12"
       >
-        <div className="sub-container">
+        <div className="sub-container" id="formview">
           <Form
             form={form}
             submission={updatedSubmission}

--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -45,6 +45,7 @@ import { getFormioRoleIds } from "../../../apiManager/services/userservices";
 import {
   getUserRolePermission,
 } from "../../../helper/user";
+import PrintPDF from "../../../helper/PrintPDF";
 import {
   STAFF_REVIEWER,
 } from "../../../constants/constants";
@@ -262,6 +263,7 @@ const ServiceFlowTaskDetails = React.memo(() => {
     return (
       <div className="service-task-details">
         <LoadingOverlay active={isTaskUpdating} spinner text={t("Loading...")}>
+          <PrintPDF />
           <TaskHeader />
           <Tabs defaultActiveKey="form" id="service-task-details" mountOnEnter>
             <Tab eventKey="form" title={t("Form")}>

--- a/forms-flow-web/src/helper/PrintPDF.js
+++ b/forms-flow-web/src/helper/PrintPDF.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { printToPDF } from "../services/PdfService";
+
+const PrintPDF = React.memo(() => {
+  const { t } = useTranslation();
+  return (
+    <div className="row ">
+        <div className="btn-right">
+        <button
+            type="button"
+            className="btn btn-primary btn-sm form-btn pull-right btn-right btn btn-primary"
+            onClick={() => printToPDF()}
+            style={{marginRight: "15px"}}
+        >
+            <i className="fa fa-print" aria-hidden="true"></i> {t(`Print As PDF`)}
+        </button>
+        </div>
+    </div>
+  );
+});
+export default PrintPDF;

--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -1,4 +1,5 @@
 import html2pdf from 'html2pdf.js';
+import { toast } from "react-toastify";
 
 export const exportToPdf = (options) => {
   const pdfPageHeight = 1500;
@@ -12,4 +13,9 @@ export const exportToPdf = (options) => {
     jsPDF: { unit: 'px', format: [mainPrintableContainer.offsetWidth, pdfPageHeight], orientation: 'portrait' }
   };
   html2pdf().set(opt).from(mainPrintableContainer).save();
+};
+
+export const printToPDF = () => {
+  toast.success("Downloading...");
+  exportToPdf({ formId: "formview" });
 };


### PR DESCRIPTION
## Summary
DGJ-640 Add the "Print As PDF" button on the application edit, Draft edit, and Task tab.

## Changes
- use existing exportToPDF() function to download PDF file.
- Add **ID** on div which is a form container to print Form as PDF.
