### PR TITLE
DGJ-636 Hide senior leadership review form the task list tab

### DIFF
--- a/forms-flow-bpm/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/forms-flow-bpm/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -348,7 +348,12 @@
               ${queryType} UPPER(RES.NAME_) not like UPPER(#{query.nameNotLike}) ESCAPE ${escapeChar}
             </if>
             <if test="query.description != null">
-              ${queryType} RES.DESCRIPTION_ = #{query.description}
+              <if test="query.description == 'hidefromtasklist'">
+                ${queryType} (RES.DESCRIPTION_ != #{query.description} OR RES.DESCRIPTION_ = '' OR RES.DESCRIPTION_ IS NULL)
+              </if>
+              <if test="query.description != 'hidefromtasklist'">
+                ${queryType} RES.DESCRIPTION_ = #{query.description}
+              </if>
             </if>
             <if test="query.descriptionLike != null">
               ${queryType} RES.DESCRIPTION_ like #{query.descriptionLike} ESCAPE ${escapeChar}

--- a/forms-flow-web/src/apiManager/services/bpmTaskServices.js
+++ b/forms-flow-web/src/apiManager/services/bpmTaskServices.js
@@ -28,7 +28,7 @@ import { replaceUrl } from "../../helper/helper";
 import axios from "axios";
 import { taskDetailVariableDataFormatter } from "./formatterService";
 import { REVIEWER_GROUP } from "../../constants/userContants";
-import { MAX_RESULTS } from "../../components/ServiceFlow/constants/taskConstants";
+import { MAX_RESULTS, HIDEFROMTASKLIST } from "../../components/ServiceFlow/constants/taskConstants";
 
 export const fetchServiceTaskList = (
   filterId,
@@ -38,6 +38,11 @@ export const fetchServiceTaskList = (
   ...rest
 ) => {
   const done = rest.length ? rest[0] : () => {};
+  // Default filter to hide tasks from the task list
+  // issue: https://github.com/bcgov/digital-journeys/issues/636
+  if (reqData.descriptionLike === undefined && reqData.description === undefined) {
+    reqData = {...reqData, description: HIDEFROMTASKLIST};
+  }
   let apiUrlgetTaskList = replaceUrl(
     API.GET_BPM_TASK_LIST_WITH_FILTER,
     "<filter_id>",

--- a/forms-flow-web/src/components/ServiceFlow/constants/taskConstants.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/taskConstants.js
@@ -183,7 +183,7 @@ export const taskFilters = [
   },
   {
     label: <Translation>{(t) => t("Description")}</Translation>,
-    key: "Description",
+    key: "description",
     operator: FILTER_OPERATOR_TYPES.LIKE,
     type: Filter_Search_Types.STRING,
     value: "",
@@ -224,3 +224,4 @@ export const QUERY_TYPES = {
   ALL: <Translation>{(t) => t("All")}</Translation>,
 };
 export const MAX_RESULTS = 15; //maxResults
+export const HIDEFROMTASKLIST = "hidefromtasklist";


### PR DESCRIPTION
## Summary
DGJ-636 Hide the Senior Leadership Review form from the task tab

## Changes
Added constant that helps to filter tasks. It must be added as a description on the Camunda process "User Tasks".



## Notes
N/A