### PR TITLE
hotfix/delete-update-application-in-ODS

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -527,8 +527,11 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
         delete_application_in_ODS_url = f"{ODS_base_url}/{slreview_endpoint}({application_id})"
         headers = {"Authorization": test_auth_token}
         try:
-            requests.delete(delete_application_in_ODS_url, headers=headers)
-            current_app.logger.info(f"application was deleted in ODS by id {application_id}")
+            response = requests.delete(delete_application_in_ODS_url, headers=headers)
+            if response.ok:
+                current_app.logger.info(f"application was deleted in ODS by id {application_id}")
+            else:
+                current_app.logger.warning(f"Something went wrong deleting application in ODS by id {application_id}")
         except:
             raise BusinessException(
                 f"Failed to delete the application in ODS at {delete_application_in_ODS_url}", 

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -80,12 +80,12 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
         boolean debug = Boolean.parseBoolean(String.valueOf(execution.getVariableLocal("debug")));
 
         if(debug) {
-            System.out.println("Sending valuse to ODS: " + json);
+            System.out.println("Sending values to ODS: " + json);
         }
 
         if (httpMethod.equals("put")) {
             this.httpServiceInvoker.execute(getEndpointUrl(endpoint, applicationId), HttpMethod.PUT, json);
-        } if (httpMethod.equals("delete")) {
+        } else if (httpMethod.equals("delete")) {
             this.httpServiceInvoker.execute(getEndpointUrl(endpoint, applicationId), HttpMethod.DELETE, json);
         } else {
             this.httpServiceInvoker.execute(getEndpointUrl(endpoint), HttpMethod.POST, json);


### PR DESCRIPTION
… send put and post requests together

## Summary

This PR fixes an issue in the condition of sending to the ODS listener in BPM. The logic made put and post requests together instead of conditionally sending one.

It also improves the error handling of deleted applications in ODS in webApi.