### PR TITLE
DGJ-640-fix-css-issue-in-export-pdf

### DIFF
--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -7,9 +7,9 @@ export const exportToPdf = (options) => {
   var opt = {
     margin: [64, 0, 64, 0],
     filename: `form-exported-${new Date().getTime()}.pdf`,
-    pagebreak: {mode: ['avoid-all']},
-    image: { type: 'jpeg', quality: 0.50 },
-    html2canvas: { scale: 2 },
+    pagebreak: {mode: ['avoid-all', 'css']},
+    image: { type: 'jpeg', quality: 1.0 },
+    html2canvas: { scale: 1 },
     jsPDF: { unit: 'px', format: [mainPrintableContainer.offsetWidth, pdfPageHeight], orientation: 'portrait' }
   };
   html2pdf().set(opt).from(mainPrintableContainer).save();


### PR DESCRIPTION
## Summary
DGJ-640 Fixed CSS does not display and content breaks in the PDF pages.

## Changes
Scale: 2 try to scale up the image for the PDF. That makes some CSS not apply issues, and for edge browsers, it breaks content between 2 pages.
I have downgraded the scale to 1. As the default value is window.devicePixelRatio that makes a bit different based on the user's browser window.

## Notes
N/A