### PR TITLE
hotfix/escape-quotes-in-sl-review-conf-page

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
@@ -129,8 +129,9 @@ export default React.memo(() => {
               <li>
                 Once the DM/executive team has validated the senior leaders’
                 readiness, please remember to go back into the system and
-                re-open the form in the "Submitted Forms" tab to document any
-                additional feedback and adjust the readiness rating as needed.
+                re-open the form in the &quot;Submitted Forms&quot; tab to
+                document any additional feedback and adjust the readiness rating
+                as needed.
               </li>
 
               <li>


### PR DESCRIPTION
## Summary

A hotfix that escapes double quotes in sl review confirmation page text.