### PR TITLE
feature/DGJ-671_manual-auto-save-for-forms

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -39,6 +39,7 @@ import {
 } from "../../constants/constants";
 import Loading from "../../containers/Loading";
 import SubmissionError from "../../containers/SubmissionError";
+// eslint-disable-next-line no-unused-vars
 import SavingLoading from "../Loading/SavingLoading";
 import { redirectToFormSuccessPage } from "../../constants/successTypes";
 import PrintPDF from "../../helper/PrintPDF";
@@ -61,6 +62,7 @@ const View = React.memo((props) => {
   const tenantKey = useSelector((state) => state.tenants?.tenantId);
   const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : "/";
   const draftSubmission = useSelector((state) => state.draft.submission);
+  // eslint-disable-next-line no-unused-vars
   const [draftSaved, setDraftSaved] = useState(false);
   const [showNotification, setShowNotification] = useState(false);
   /**
@@ -149,7 +151,7 @@ const View = React.memo((props) => {
 
   return (
     <div className="container overflow-y-auto">
-      {
+      {/* {
         <>
           <span className="pr-2  mr-2 d-flex justify-content-end align-items-center">
             {poll && showNotification && (
@@ -160,7 +162,7 @@ const View = React.memo((props) => {
             )}
           </span>
         </>
-      }
+      } */}
       <div className="d-flex align-items-center justify-content-between">
         <div className="main-header">
           <SubmissionError
@@ -216,7 +218,16 @@ const View = React.memo((props) => {
                 exitType.current = "SUBMIT";
                 onSubmit(data, form._id, isPublic);
               }}
-              onCustomEvent={(evt) => onCustomEvent(evt, redirectUrl)}
+              onCustomEvent={(evt) => {
+                onCustomEvent(evt, redirectUrl);
+                if (evt.type === "saveDraft") {
+                  let payload = getDraftReqFormat(formId, { ...draftData });
+                  saveDraft(payload);
+                  toast.success(
+                    <Translation>{(t) => t("Saved as draft")}</Translation>
+                  );
+                }
+              }}
             />
           }
         </div>

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -210,6 +210,9 @@ const Edit = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.ACTION_COMPLETE:
         onApplicationFormSubmit(customEvent.actionType, customEvent.successPage);
         break;
+      case CUSTOM_EVENT_TYPE.SAVE_DRAFT:
+        toast.success(<Translation>{(t) => t("Saved as draft")}</Translation>);
+        break;
       default:
         return;
     }

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -56,6 +56,7 @@ import useInterval from "../../../customHooks/useInterval";
 import selectApplicationCreateAPI from "./apiSelectHelper";
 import { getFormProcesses } from "../../../apiManager/services/processServices";
 import { setFormStatusLoading } from "../../../actions/processActions";
+// eslint-disable-next-line no-unused-vars
 import SavingLoading from "../../Loading/SavingLoading";
 
 import { fetchEmployeeData } from "../../../apiManager/services/employeeDataService";
@@ -105,7 +106,9 @@ const View = React.memo((props) => {
   const [showPublicForm, setShowPublicForm] = useState("checking");
   const [poll, setPoll] = useState(DRAFT_ENABLED);
   const exitType = useRef("UNMOUNT");
+  // eslint-disable-next-line no-unused-vars
   const [draftSaved, setDraftSaved] = useState(false);
+  // eslint-disable-next-line no-unused-vars
   const [notified, setNotified] = useState(false);
   const [defaultVals, setDefaultVals] = useState({});
 
@@ -399,7 +402,7 @@ const View = React.memo((props) => {
 
   return (
     <div className="container overflow-y-auto">
-      {DRAFT_ENABLED &&
+      {/* {DRAFT_ENABLED &&
         isAuthenticated &&
         (formStatus === "active" ||
           (publicFormStatus?.anonymous === true &&
@@ -421,7 +424,7 @@ const View = React.memo((props) => {
               )}
             </span>
           </>
-        )}
+        )} */}
       <div className="d-flex align-items-center justify-content-between">
         <div className="main-header">
           <SubmissionError
@@ -500,7 +503,18 @@ const View = React.memo((props) => {
                 exitType.current = "SUBMIT";
                 onSubmit(data, form._id, isPublic);
               }}
-              onCustomEvent={(evt) => onCustomEvent(evt, redirectUrl)}
+              onCustomEvent={(evt) => {
+                onCustomEvent(evt, redirectUrl);
+                if (evt.type === "saveDraft") {
+                  let payload = getDraftReqFormat(validFormId, {
+                    ...draftData?.data,
+                  });
+                  saveDraft(payload);
+                  toast.success(
+                    <Translation>{(t) => t("Saved as draft")}</Translation>
+                  );
+                }
+              }}
               ref={formRef}
             />
           ) : formStatus === "inactive" || !formStatus ? (

--- a/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
@@ -4,4 +4,5 @@ export const CUSTOM_EVENT_TYPE = {
   CUSTOM_SUBMIT_DONE: "customSubmitDone",
   ACTION_COMPLETE: "actionComplete",
   CANCEL_SUBMISSION: "cancelSubmission",
+  SAVE_DRAFT: "saveDraft",
 };


### PR DESCRIPTION
## Summary

This PR adds a manual save as a draft feature to forms (as part of ticket #671).

## Changes
- Autosave UI was disabled in submitting a new form and editing draft form pages.
- A custom event handler was added to the new form/draft form/edit submitted form pages.
 

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
- The exact message and whether a confirmation page is needed after save as a draft, is still in discussion and can be added later to this or another ticket.
- Another part of this feature lies in the `save` button that is added to each form and emits a custom event to save the form as well as trigger the form validation in case of saving a submitted form. That logic is added below:
```javascript
if (!data.task) {
 form.emit('customEvent', {
    type: "saveDraft",
    component: component
  });
} else {
  form.setPristine(false)
  const isFormValid = form.checkValidity(null, true, null, true);
  if (isFormValid) {
    const submissionId = form._submission._id;
    const formDataReqUrl = form.formio.formUrl+'/submission/'+submissionId;
    const formDataReqObj1 =  {  "_id": submissionId,  "data": data};
    const formio = new Formio(formDataReqUrl);
    formio.saveSubmission(formDataReqObj1).then( result => {
      form.emit('customEvent', {
        type: "saveDraft",
        component: component
      });
    }).catch((error)=>{
      //Error callback on not Save
      consloe.error(error);
    }); 
  }
}
```

