### PR TITLE
bugfix/DGJ-665_tasks-loading-issue

### DIFF
--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -119,6 +119,7 @@ const ServiceFlowTaskDetails = React.memo(() => {
     (formUrl) => {
       const { formId, submissionId } = getFormIdSubmissionIdFromURL(formUrl);
       Formio.clearCache();
+      dispatch(resetFormData("form"));
       function fetchForm() {
         dispatch(
           getForm("form", formId, (err) => {


### PR DESCRIPTION
## Summary

This PR fixes the issue of loading subsequent forms under the tasks tab. This issue only happened when the user selected a form under tasks and came back to this page to select another,

## Changes
- Resetting the formData (task detail) once a new form (task) is selected

## Notes
I found the solution in AOT v5.1. Seems like they missed it in v5.0.