### PR TITLE
DGJ-686 Style border of select dropdowns same as text fields

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -664,6 +664,14 @@ h4 {
   outline-offset: 1px;
 }
 
+.ui.selection.dropdown {
+  // Bring sizing of dropdown in line with textboxes
+  padding: 0.375rem 0.75rem;
+  height: calc(1.6em + 0.75rem + 2px);
+  line-height: 1.6;
+  min-height: auto;
+}
+
 .field-required::after {
   content: "";
 }

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -653,7 +653,9 @@ h4 {
   font-weight: 700;
 }
 
-.form-control {
+.form-control,
+.ui.selection.dropdown,
+.ui.selection.dropdown:hover {
   border: 2px solid $componentColor;
 }
 


### PR DESCRIPTION
## Summary
- Changed the border color of select dropdowns to match text fields
- Changed the sizing of select dropdowns to match text fields

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->
Before: 
![image](https://user-images.githubusercontent.com/66635118/200029972-a96c04cd-bbee-488f-b5f2-95fe75196efc.png)

After:
![image](https://user-images.githubusercontent.com/66635118/200030008-09de326c-9768-4904-8a33-918cd088bcc0.png)


## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->