### PR TITLE
feature/DGJ-680_floating-button

### DIFF
--- a/formio-upload/pdf-generation/formio.html
+++ b/formio-upload/pdf-generation/formio.html
@@ -60,6 +60,10 @@
           page-break-inside: avoid;
       }
 
+      button.floatingButton {
+        display: none !important;
+      }
+
     </style>
     <title>Form</title>
   </head>

--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -42,7 +42,7 @@ import SubmissionError from "../../containers/SubmissionError";
 // eslint-disable-next-line no-unused-vars
 import SavingLoading from "../Loading/SavingLoading";
 import { redirectToFormSuccessPage } from "../../constants/successTypes";
-import PrintPDF from "../../helper/PrintPDF";
+import { printToPDF } from "../../services/PdfService";
 
 const View = React.memo((props) => {
   const { t } = useTranslation();
@@ -149,6 +149,25 @@ const View = React.memo((props) => {
     );
   }
 
+  const handleCustomEvent = (evt) => {
+    switch (evt.type) {
+      case CUSTOM_EVENT_TYPE.SAVE_DRAFT: {
+        let payload = getDraftReqFormat(formId, { ...draftData });
+        saveDraft(payload);
+        toast.success(
+          <Translation>{(t) => t("Submission saved to Draft Forms")}</Translation>
+        );
+        break;
+      }
+      case CUSTOM_EVENT_TYPE.PRINT_PDF: {
+        printToPDF();
+        break;
+      }
+      default:
+        return;
+    }
+  };
+
   return (
     <div className="container overflow-y-auto">
       {/* {
@@ -196,7 +215,6 @@ const View = React.memo((props) => {
         text={<Translation>{(t) => t("Loading...")}</Translation>}
         className="col-12"
       >
-        <PrintPDF />
         <div className="ml-4 mr-4" id="formview">
           {
             <Form
@@ -220,15 +238,7 @@ const View = React.memo((props) => {
               }}
               onCustomEvent={(evt) => {
                 onCustomEvent(evt, redirectUrl);
-                if (evt.type === CUSTOM_EVENT_TYPE.SAVE_DRAFT) {
-                  let payload = getDraftReqFormat(formId, { ...draftData });
-                  saveDraft(payload);
-                  toast.success(
-                    <Translation>
-                      {(t) => t("Submission saved to Draft Forms")}
-                    </Translation>
-                  );
-                }
+                handleCustomEvent(evt);
               }}
             />
           }

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -54,7 +54,7 @@ import {
 import { getTaskSubmitFormReq } from "../../../../../apiManager/services/bpmServices";
 import { redirectToSuccessPage } from "../../../../../constants/successTypes";
 import { CUSTOM_EVENT_TYPE } from "../../../../ServiceFlow/constants/customEventTypes";
-import PrintPDF from "../../../../../helper/PrintPDF";
+import { printToPDF } from "../../../../../services/PdfService";
 
 const Edit = React.memo((props) => {
   const { t } = useTranslation();
@@ -209,7 +209,10 @@ const Edit = React.memo((props) => {
   const onApplicationFormSubmitCustomEvent = (customEvent) => {
     switch (customEvent.type) {
       case CUSTOM_EVENT_TYPE.ACTION_COMPLETE:
-        onApplicationFormSubmit(customEvent.actionType, customEvent.successPage);
+        onApplicationFormSubmit(
+          customEvent.actionType,
+          customEvent.successPage
+        );
         break;
       case CUSTOM_EVENT_TYPE.SAVE_DRAFT:
         toast.success(
@@ -218,6 +221,10 @@ const Edit = React.memo((props) => {
           </Translation>
         );
         break;
+      case CUSTOM_EVENT_TYPE.PRINT_PDF:
+        printToPDF();
+        break;
+      
       default:
         return;
     }
@@ -251,9 +258,6 @@ const Edit = React.memo((props) => {
         text={t("Loading...")}
         className="col-12"
       >
-        {showPrintButton ? (
-        <PrintPDF />
-        ) : null }
         <div className="ml-4 mr-4" id="formview">
           <Form
             form={form}

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { connect, useSelector } from "react-redux";
 import {
   selectRoot,
@@ -22,7 +22,8 @@ import { updateCustomSubmission } from "../../../../../apiManager/services/FormS
 // import DownloadPDFButton from "../../../ExportAsPdf/downloadPdfButton";
 
 import { exportToPdf } from "../../../../../services/PdfService";
-import { Button } from "react-bootstrap";
+import { enableFormButton } from "../../../../../helper/formUtils";
+import { toast } from "react-toastify";
 
 
 const View = React.memo((props) => {
@@ -34,7 +35,7 @@ const View = React.memo((props) => {
     errors,
     form: { form, isActive: isFormActive },
     submission: { submission, isActive: isSubActive, url },
-    showPrintButton,
+    // showPrintButton,
   } = props;
   const isFormSubmissionLoading = useSelector(
     (state) => state.formDelete.isFormSubmissionLoading
@@ -43,6 +44,27 @@ const View = React.memo((props) => {
   const customSubmission = useSelector(
     (state) => state.formDelete.customSubmission
   );
+
+  const formRef = useRef(null);
+  let enableFormButtonInterval = null;
+  useEffect(() => {
+    enableFormButtonInterval = setInterval(() => {
+      enableFormButton(
+        formRef.current?.formio,
+        enableFormButtonInterval,
+        "printPdf",
+        printToPDF
+      );
+    }, 1000);
+    return () => {
+      clearInterval(enableFormButtonInterval);
+    };
+  });
+
+  const printToPDF = () => {
+    toast.success("Downloading...");
+    exportToPdf({ formId: "formview" });
+  };
 
   let updatedSubmission;
   if (CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {
@@ -59,21 +81,15 @@ const View = React.memo((props) => {
     <div className="container row task-container">
       <div className="main-header">
         <h3 className="task-head"> {form.title}</h3>
-        {showPrintButton && form?._id ? (
+        {/* {showPrintButton && form?._id ? (
           <div className="btn-right d-flex flex-row">
-            {/* <DownloadPDFButton
+            <DownloadPDFButton
               form_id={form._id}
               submission_id={updatedSubmission._id}
               title={form.title}
-            /> */}
-            <Button
-              className="btn btn-primary btn-sm form-btn pull-right btn-right"
-              onClick={() => exportToPdf({ formId: "formview" })}
-            >
-              <i className="fa fa-print" aria-hidden="true" /> Print As PDF
-            </Button>
+            />
           </div>
-        ) : null}
+        ) : null} */}
       </div>
 
       <Errors errors={errors} />
@@ -91,6 +107,7 @@ const View = React.memo((props) => {
             hideComponents={hideComponents}
             onSubmit={onSubmit}
             options={{ ...options, i18n: formio_resourceBundles }}
+            ref={formRef}
           />
         </div>
       </LoadingOverlay>
@@ -98,10 +115,9 @@ const View = React.memo((props) => {
   );
 });
 
-View.defaultProps = {
-  showPrintButton: true,
-};
-
+// View.defaultProps = {
+//   showPrintButton: true,
+// };
 const mapStateToProps = (state, props) => {
   const isDraftView = props.page === "draft-detail" ? true : false;
   return {
@@ -112,6 +128,9 @@ const mapStateToProps = (state, props) => {
     options: {
       readOnly: true,
       language: state.user.lang,
+      hide: {
+        saveAsDraft: true,
+      },
     },
     errors: [selectError("submission", state), selectError("form", state)],
   };

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
@@ -21,9 +21,8 @@ import {
 import { updateCustomSubmission } from "../../../../../apiManager/services/FormServices";
 // import DownloadPDFButton from "../../../ExportAsPdf/downloadPdfButton";
 
-import { exportToPdf } from "../../../../../services/PdfService";
+import { printToPDF } from "../../../../../services/PdfService";
 import { enableFormButton } from "../../../../../helper/formUtils";
-import { toast } from "react-toastify";
 
 
 const View = React.memo((props) => {
@@ -60,11 +59,6 @@ const View = React.memo((props) => {
       clearInterval(enableFormButtonInterval);
     };
   });
-
-  const printToPDF = () => {
-    toast.success("Downloading...");
-    exportToPdf({ formId: "formview" });
-  };
 
   let updatedSubmission;
   if (CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -398,6 +398,29 @@ const View = React.memo((props) => {
     exportToPdf({ formId: "formview" });
   };
 
+  const handleCustomEvent = (evt) => {
+    switch (evt.type) {
+      case CUSTOM_EVENT_TYPE.SAVE_DRAFT: {
+        let payload = getDraftReqFormat(validFormId, {
+          ...draftData?.data,
+        });
+        saveDraft(payload);
+        toast.success(
+          <Translation>
+            {(t) => t("Submission saved to Draft Forms")}
+          </Translation>
+        );
+        break;
+      }
+      case CUSTOM_EVENT_TYPE.PRINT_PDF: 
+        printToPDF();
+        break;
+      
+      default:
+        return;
+    }
+  };
+
 
 
   return (
@@ -471,17 +494,6 @@ const View = React.memo((props) => {
         }
         className="col-12"
       >
-        <div className="row">
-          <div className="btn-right">
-            <button
-              type="button"
-              className="btn btn-primary btn-sm form-btn pull-right btn-right btn btn-primary"
-              onClick={() => printToPDF()}
-            >
-              <i className="fa fa-print" aria-hidden="true"></i> Print As PDF
-            </button>
-          </div>
-        </div>
         <div className="ml-4 mr-4" id="formview">
           {isPublic || formStatus === "active" ? (
             <Form
@@ -505,17 +517,7 @@ const View = React.memo((props) => {
               }}
               onCustomEvent={(evt) => {
                 onCustomEvent(evt, redirectUrl);
-                if (evt.type === CUSTOM_EVENT_TYPE.SAVE_DRAFT) {
-                  let payload = getDraftReqFormat(validFormId, {
-                    ...draftData?.data,
-                  });
-                  saveDraft(payload);
-                  toast.success(
-                    <Translation>
-                      {(t) => t("Submission saved to Draft Forms")}
-                    </Translation>
-                  );
-                }
+                handleCustomEvent(evt);
               }}
               ref={formRef}
             />

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -407,7 +407,7 @@ const View = React.memo((props) => {
         );
         break;
       }
-      case CUSTOM_EVENT_TYPE.PRINT_PDF: 
+      case CUSTOM_EVENT_TYPE.PRINT_PDF:
         printToPDF();
         break;
       

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -60,7 +60,7 @@ import { setFormStatusLoading } from "../../../actions/processActions";
 import SavingLoading from "../../Loading/SavingLoading";
 
 import { fetchEmployeeData } from "../../../apiManager/services/employeeDataService";
-import { exportToPdf } from "../../../services/PdfService";
+import { printToPDF } from "../../../services/PdfService";
 import { convertFormLinksToOpenInNewTabs } from "../../../helper/formUtils";
 import { redirectToFormSuccessPage } from "../../../constants/successTypes";
 
@@ -392,11 +392,6 @@ const View = React.memo((props) => {
       </div>
     );
   }
-
-  const printToPDF = () => {
-    toast.success("Downloading...");
-    exportToPdf({ formId: "formview" });
-  };
 
   const handleCustomEvent = (evt) => {
     switch (evt.type) {

--- a/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
@@ -5,4 +5,5 @@ export const CUSTOM_EVENT_TYPE = {
   ACTION_COMPLETE: "actionComplete",
   CANCEL_SUBMISSION: "cancelSubmission",
   SAVE_DRAFT: "saveDraft",
+  PRINT_PDF: "printPDF",
 };

--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -49,8 +49,7 @@ import {
   STAFF_REVIEWER,
 } from "../../../constants/constants";
 import { redirectToSuccessPage } from "../../../constants/successTypes";
-import { toast } from "react-toastify";
-import { exportToPdf } from "../../../services/PdfService";
+import { printToPDF } from "../../../services/PdfService";
 
 const ServiceFlowTaskDetails = React.memo(() => {
   const { t } = useTranslation();
@@ -248,11 +247,6 @@ const ServiceFlowTaskDetails = React.memo(() => {
     } else {
       reloadCurrentTask();
     }
-  };
-
-  const printToPDF = () => {
-    toast.success("Downloading...");
-    exportToPdf({ formId: "formview" });
   };
 
   if (!bpmTaskId) {

--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -45,11 +45,12 @@ import { getFormioRoleIds } from "../../../apiManager/services/userservices";
 import {
   getUserRolePermission,
 } from "../../../helper/user";
-import PrintPDF from "../../../helper/PrintPDF";
 import {
   STAFF_REVIEWER,
 } from "../../../constants/constants";
 import { redirectToSuccessPage } from "../../../constants/successTypes";
+import { toast } from "react-toastify";
+import { exportToPdf } from "../../../services/PdfService";
 
 const ServiceFlowTaskDetails = React.memo(() => {
   const { t } = useTranslation();
@@ -208,6 +209,9 @@ const ServiceFlowTaskDetails = React.memo(() => {
       case CUSTOM_EVENT_TYPE.ACTION_COMPLETE:
         onFormSubmitCallback(customEvent.actionType, customEvent.successPage);
         break;
+      case CUSTOM_EVENT_TYPE.PRINT_PDF:
+        printToPDF();
+        break;
       default:
         return;
     }
@@ -246,6 +250,11 @@ const ServiceFlowTaskDetails = React.memo(() => {
     }
   };
 
+  const printToPDF = () => {
+    toast.success("Downloading...");
+    exportToPdf({ formId: "formview" });
+  };
+
   if (!bpmTaskId) {
     return (
       <Row className="not-selected mt-2 ml-1 " style={{ color: "#757575" }}>
@@ -264,7 +273,6 @@ const ServiceFlowTaskDetails = React.memo(() => {
     return (
       <div className="service-task-details">
         <LoadingOverlay active={isTaskUpdating} spinner text={t("Loading...")}>
-          <PrintPDF />
           <TaskHeader />
           <Tabs defaultActiveKey="form" id="service-task-details" mountOnEnter>
             <Tab eventKey="form" title={t("Form")}>

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -27,4 +27,21 @@ const scrollToErrorOnValidation = (formio, scrollToErrorInterval) => {
   }
 };
 
-export { convertFormLinksToOpenInNewTabs, scrollToErrorOnValidation };
+const enableFormButton = (formio, enableButtonInterval, buttonKey, onClick) => {
+  if (formio) {
+    clearInterval(enableButtonInterval);
+    const button = document.getElementsByName(`data[${buttonKey}]`)[0];
+    if (button) {
+      button.removeAttribute("disabled");
+      if (onClick) {
+        button.onclick = onClick;
+      }
+    }
+  }
+};
+
+export {
+  convertFormLinksToOpenInNewTabs,
+  scrollToErrorOnValidation,
+  enableFormButton,
+};

--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -16,6 +16,12 @@ export const exportToPdf = (options) => {
 };
 
 export const printToPDF = () => {
+  // Hiding the floating buttons during the PDF generation
+  const floatingButtons = document.querySelectorAll("button.floatingButton");
+  floatingButtons.forEach((btmElm) => btmElm.style.visibility = "hidden");
   toast.success("Downloading...");
   exportToPdf({ formId: "formview" });
+  setTimeout(() => {
+      floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "visible"));
+    }, 2000);
 };

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -992,18 +992,18 @@ a{
   }
 }
 
-button.floatingButton1 {
+button.floatingButton {
   position:fixed;
-	bottom: 40px;
-	right: 40px;
   z-index: 1;
   box-shadow: 0px 3px 6px #666;
 }
 
-button.floatingButton2 {
-  position:fixed;
+button.floatingButton.floating-right-bottom-1 {
+	bottom: 40px;
+	right: 40px;
+}
+
+button.floatingButton.floating-right-bottom-2 {
 	bottom: 110px;
 	right: 40px;
-  z-index: 1;
-  box-shadow: 0px 3px 6px #666;
 }

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -991,3 +991,19 @@ a{
     }
   }
 }
+
+button.floatingButton1 {
+  position:fixed;
+	bottom: 40px;
+	right: 40px;
+  z-index: 1;
+  box-shadow: 0px 3px 6px #666;
+}
+
+button.floatingButton2 {
+  position:fixed;
+	bottom: 110px;
+	right: 40px;
+  z-index: 1;
+  box-shadow: 0px 3px 6px #666;
+}


### PR DESCRIPTION
## Summary

This PR would allow a Form designer to add floating buttons to the forms.

## Changes
- Adding floating styles that a designer can use to make a button float on two positions (more can be added per request).
- Make the PDF button a custom form.io button that emits the print event to the different components.
- Adding the necessary logic to hide all floating buttons during the PDF generation on FE.
- Make the `PrintPDF` button enable and `saveAsDraft` hidden on `submission.view` page (only applicable to Telework) 

## Notes

The floating button will be positioned on top of the page on the server-generated PDFs. I didn't spend time removing them from that pdf since we might replace it with the AOT PDF generator in the future. See below image:
<img width="922" alt="Screen Shot 2022-11-09 at 5 53 01 PM" src="https://user-images.githubusercontent.com/77303486/200981096-a05bb581-ea49-4f1a-b72d-ac21687405d5.png">



## Screenshots (if applicable)
<img width="566" alt="Screen Shot 2022-11-09 at 5 48 50 PM" src="https://user-images.githubusercontent.com/77303486/200980706-63b0e41f-a6ff-4f1f-8cd0-57cbedb76ed6.png">
<img width="1457" alt="Screen Shot 2022-11-09 at 5 49 06 PM" src="https://user-images.githubusercontent.com/77303486/200980714-6d5f5aba-dcc3-44ec-b02a-ee73b552e2fe.png">
<img width="1424" alt="Screen Shot 2022-11-09 at 5 49 28 PM" src="https://user-images.githubusercontent.com/77303486/200980718-6c41de65-14b8-4754-9f44-117db0f80faa.png">
<img width="1440" alt="Screen Shot 2022-11-09 at 5 49 42 PM" src="https://user-images.githubusercontent.com/77303486/200980720-e2c57360-c935-44ce-97de-658bf67afdfb.png">




