### PR TITLE
DGJ-709 Add button to draft forms in forms tab table

### DIFF
--- a/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
+++ b/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
@@ -27,6 +27,9 @@ const FormOperations = React.memo(({ formData }) => {
   const submitNewForm = (formId) => {
     dispatch(push(`${redirectUrl}form/${formId}`));
   };
+  const draftForms = () => {
+    dispatch(push(`${redirectUrl}draft`));
+  };
   const viewOrEditForm = (formId) => {
     dispatch(resetFormProcessData());
     dispatch(setResetProcess());
@@ -76,6 +79,15 @@ const FormOperations = React.memo(({ formData }) => {
       <Translation>{(t) => t("View/Edit Form")}</Translation>{" "}
     </button>
   );
+  const draftFormsTab = (
+    <button
+      className="btn btn-outline-primary"
+      onClick={() => draftForms()}
+    >
+      <i className="fa fa-pencil-square-o mr-1"  />
+      <Translation>{(t) => t("Draft Forms")}</Translation>{" "}
+    </button>
+  );
   const deleteForm = (
     <i
       className="fa fa-trash fa-lg delete_button"
@@ -84,7 +96,7 @@ const FormOperations = React.memo(({ formData }) => {
   );
 
   let buttons = {
-    CLIENT_OR_REVIEWER: [submitNew],
+    CLIENT_OR_REVIEWER: [submitNew, draftFormsTab],
     STAFF_DESIGNER: [viewOrEdit, deleteForm],
   };
   const formButtonOperations = () => {

--- a/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
+++ b/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { push } from "connected-react-router";
+import { Link } from "react-router-dom";
 import {
   CLIENT,
   MULTITENANCY_ENABLED,
@@ -26,9 +27,6 @@ const FormOperations = React.memo(({ formData }) => {
   const userRoles = useSelector((state) => state.user.roles);
   const submitNewForm = (formId) => {
     dispatch(push(`${redirectUrl}form/${formId}`));
-  };
-  const draftForms = () => {
-    dispatch(push(`${redirectUrl}draft`));
   };
   const viewOrEditForm = (formId) => {
     dispatch(resetFormProcessData());
@@ -80,13 +78,12 @@ const FormOperations = React.memo(({ formData }) => {
     </button>
   );
   const draftFormsTab = (
-    <button
-      className="btn btn-outline-primary"
-      onClick={() => draftForms()}
-    >
-      <i className="fa fa-pencil-square-o mr-1"  />
-      <Translation>{(t) => t("Draft Forms")}</Translation>{" "}
-    </button>
+    <Link to={`${redirectUrl}draft`} style={{ textDecoration: "none" }}>
+        <span style={{ color: "#0071EB", cursor: "pointer", fontSize: "20px" }}>
+          <i className="fa fa-pencil-square-o" aria-hidden="true" />{" "}
+          <Translation>{(t) => t("Draft Forms")}</Translation>{" "}
+        </span>
+    </Link>
   );
   const deleteForm = (
     <i

--- a/forms-flow-web/src/containers/styles.scss
+++ b/forms-flow-web/src/containers/styles.scss
@@ -412,7 +412,7 @@
 
 .menu-padded {
   padding: 5px 0 5px 0;
-  font-size: 1rem;
+  font-size: 21px;
 }
 
 .margin-bottom-10 {


### PR DESCRIPTION
## Summary
DGJ-709 Add button to draft forms in forms tab tabl

## Changes
Add redirect to /draft page button and enable it for client and reviewer roles in the formOperations file.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/99269796/201101186-29f01624-ce9e-40c3-89dd-61937bffdee5.png)
