### PR TITLE
DGJ-722 SL Review: Don't save if there is no Employee Name in the form

### DIFF
--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -186,6 +186,11 @@ const View = React.memo((props) => {
    */
   const saveDraft = (payload, exitType = exitType) => {
     let dataChanged = !isEqual(payload.data, lastUpdatedDraft.data);
+    // check if draftsave is disebled in form or not
+    if (payload.data?.isSaveDraftEnabled !== undefined &&
+        payload.data?.isSaveDraftEnabled === false) {
+      return;
+    }
     if (draftSubmissionId && isDraftCreated) {
       if (dataChanged) {
         setDraftSaved(false);
@@ -410,7 +415,9 @@ const View = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.PRINT_PDF:
         printToPDF();
         break;
-      
+      case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
+        toast.error(evt.error);
+        break;
       default:
         return;
     }

--- a/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
@@ -6,4 +6,5 @@ export const CUSTOM_EVENT_TYPE = {
   CANCEL_SUBMISSION: "cancelSubmission",
   SAVE_DRAFT: "saveDraft",
   PRINT_PDF: "printPDF",
+  ERROR_CUSTOM_VALIDATION: "errorCustomValidation",
 };


### PR DESCRIPTION
## Summary
Added script in SL review that ensures the form must not save if employee name is not provided.

## Changes
- Added Hidden field in SL review form and set a default value to true, If the name is not selected then it will change to false and that will stop auto-save.
- If the name is not selected and someone is trying to save by clicking on the button, it will show a toast message, please check the attached screenshot for reference.

## Screenshots (if applicable)
<img width="1439" alt="Screenshot 2022-11-21 at 5 23 04 PM" src="https://user-images.githubusercontent.com/99269796/203052758-6eb5d2a6-5cfc-4670-a149-ed01befedaa4.png">
