### PR TITLE
form is redraw after links conversion and make sure it runs once

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -224,7 +224,9 @@ const Edit = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.PRINT_PDF:
         printToPDF();
         break;
-      
+      case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
+        toast.error(customEvent.error);
+        break;  
       default:
         return;
     }

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
@@ -22,7 +22,7 @@ import { updateCustomSubmission } from "../../../../../apiManager/services/FormS
 // import DownloadPDFButton from "../../../ExportAsPdf/downloadPdfButton";
 
 import { printToPDF } from "../../../../../services/PdfService";
-import { enableFormButton } from "../../../../../helper/formUtils";
+import { convertFormLinksToOpenInNewTabs, enableFormButton } from "../../../../../helper/formUtils";
 
 
 const View = React.memo((props) => {
@@ -57,6 +57,19 @@ const View = React.memo((props) => {
     }, 1000);
     return () => {
       clearInterval(enableFormButtonInterval);
+    };
+  });
+
+  let convertFormLinksInterval = null;
+  useEffect(() => {
+    convertFormLinksInterval = setInterval(() => {
+      convertFormLinksToOpenInNewTabs(
+        formRef.current?.formio,
+        convertFormLinksInterval
+      );
+    }, 1000);
+    return () => {
+      clearInterval(convertFormLinksInterval);
     };
   });
 

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -66,6 +66,7 @@ import { redirectToFormSuccessPage } from "../../../constants/successTypes";
 
 const View = React.memo((props) => {
   const [formStatus, setFormStatus] = React.useState("");
+  const [areFormLinksWereConverted, setAreFormLinksWereConverted] = React.useState(false);
   const { t } = useTranslation();
   const lang = useSelector((state) => state.user.lang);
   const formStatusLoading = useSelector(
@@ -362,11 +363,15 @@ const View = React.memo((props) => {
 
   let convertFormLinksInterval = null;
   useEffect(() => {
+    if (areFormLinksWereConverted) {
+      return; 
+    }
     convertFormLinksInterval = setInterval(() => {
-      convertFormLinksToOpenInNewTabs(
+      const done = convertFormLinksToOpenInNewTabs(
         formRef.current?.formio,
         convertFormLinksInterval
       );
+      setAreFormLinksWereConverted(done);
     }, 1000);
     return () => {
       clearInterval(convertFormLinksInterval);

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -10,6 +10,8 @@ const convertFormLinksToOpenInNewTabs = (formio, convertFormLinksInterval) => {
       }
     });
   }
+  formio.redraw();
+  return true;
 };
 
 const scrollToErrorOnValidation = (formio, scrollToErrorInterval) => {


### PR DESCRIPTION
## Summary

This PR fixes the issue of forms' links were not open in new tabs. #742 

## Changes
- Redraw the form after changes to the form `HTML` strings to make sure converted links are properly rendered
- Ensure that the redraw only runs once otherwise, it will clear forms validations and some other side-effects
