### PR TITLE
DGJ-723-allow-build-to-run-manually

### DIFF
--- a/.github/workflows/forms-flow-web-cd.yml
+++ b/.github/workflows/forms-flow-web-cd.yml
@@ -24,7 +24,8 @@ defaults:
 
 jobs:
   build-and-push-image:
-    if: github.event_name == 'push' && github.repository == 'bcgov/digital-journeys'
+    #if: github.event_name == 'push' && github.repository == 'bcgov/digital-journeys'
+    name: Build Image
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Allow web build to run using a manual trigger
