### PR TITLE
Dgj 765 apply new css for data-grid

### DIFF
--- a/forms-flow-web/src/components/Footer/Footer.js
+++ b/forms-flow-web/src/components/Footer/Footer.js
@@ -25,7 +25,7 @@ const BCGovFooter = React.memo(() => {
       label: "Copyright",
     },
     {
-      href: "https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111",
+      href: "mailto:digitaljourneys@gov.bc.ca",
       label: "Contact Us",
     },
   ];

--- a/forms-flow-web/src/components/Footer/Footer.js
+++ b/forms-flow-web/src/components/Footer/Footer.js
@@ -25,7 +25,7 @@ const BCGovFooter = React.memo(() => {
       label: "Copyright",
     },
     {
-      href: "mailto:digitaljourneys@gov.bc.ca",
+      href: "https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111",
       label: "Contact Us",
     },
   ];

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -449,6 +449,43 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
 .table-bordered thead td {
   background-color: $whileBackgroundColor !important;
 }
+.formio-component-datagrid .datagrid-table>tbody>tr>td:last-child,
+.formio-component-datagrid .datagrid-table>thead>tr>th:last-child {
+  padding: 0px;
+  width: 0px;
+}
+.formio-component-datagrid .datagrid-table,
+.formio-component-datagrid .datagrid-table>tfoot>tr>td {
+  border: none;
+}
+.formio-component-datagrid .datagrid-table>tfoot>tr>td {
+  border: none;
+  text-align: right;
+}
+.formio-component-datagrid .datagrid-table>thead {
+  display: none;
+}
+.formio-component-datagrid .datagrid-table>tbody>tr>td>button.formio-button-remove-row {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  border: none;
+  padding: 0 5px;
+}
+.datagrid-table .fieldset-body {
+  display: flex;
+  flex-wrap: wrap;
+}
+.datagrid-table .fieldset-body .formio-component{
+  flex: 0 0 100%;
+  padding-left: 1.25rem;
+  padding-right: 0.25rem;
+}
+@media (min-width: 768px) {
+  .datagrid-table .fieldset-body .formio-component {
+    flex: 0 0 41.67%;
+  }
+}
 .navbar-dark.navbar-toggler {
   border-color: white;
 }

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -471,10 +471,14 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
 }*/
 .formio-component-datagrid .datagrid-table>tbody>tr>td>button.formio-button-remove-row {
   position: absolute;
-  top: 0px;
-  right: 0px;
-  border: none;
-  padding: 0 5px;
+  /*bottom: 1.0rem;*/
+  top: 1rem;
+  right: 1.15rem;
+  padding: 10px 25px;
+  white-space: nowrap;
+}
+.formio-component-datagrid .datagrid-table>tbody>tr>td>button.formio-button-remove-row:after {
+  content: "Remove Section";
 }
 /*.datagrid-table .fieldset-body {
   display: flex;
@@ -484,6 +488,8 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
   /*flex: 0 0 100%;*/
   padding-left: 1.25rem;
   padding-right: 0.25rem;
+  /*padding-bottom: 1.75rem;*/
+  padding-top: 1.75rem;
 }
 @media (min-width: 768px) {
   .datagrid-table .fieldset-body .formio-component {

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -465,6 +465,10 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
 .formio-component-datagrid .datagrid-table>thead {
   display: none;
 }
+/*.formio-component-datagrid .datagrid-table>tfoot>tr>td>button.formio-button-add-row {
+  background: white;
+  color: $linkColor;
+}*/
 .formio-component-datagrid .datagrid-table>tbody>tr>td>button.formio-button-remove-row {
   position: absolute;
   top: 0px;
@@ -472,12 +476,12 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
   border: none;
   padding: 0 5px;
 }
-.datagrid-table .fieldset-body {
+/*.datagrid-table .fieldset-body {
   display: flex;
   flex-wrap: wrap;
-}
-.datagrid-table .fieldset-body .formio-component{
-  flex: 0 0 100%;
+}*/
+.formio-component-datagrid .datagrid-table fieldset {
+  /*flex: 0 0 100%;*/
   padding-left: 1.25rem;
   padding-right: 0.25rem;
 }


### PR DESCRIPTION
## Summary
DGJ-765 apply new css for data-grid
DGJ-732 contact us should open mail for DJ email.

## Changes
- Add a new stylesheet that overrides data-grid CSS. (check out screenshots)
- Considering that we will add it as same, I have added flex with 2 inputs in a row if the width is >768px.
- Change contact link to mailto: {DJ email}

## Screenshots (if applicable)
Single
<img width="1410" alt="Screenshot 2022-12-01 at 6 17 43 PM" src="https://user-images.githubusercontent.com/99269796/205058398-01c2540f-64d6-443d-a70e-a47e419cd24e.png">

After adding duplicate details.
<img width="1216" alt="Screenshot 2022-12-01 at 6 18 19 PM" src="https://user-images.githubusercontent.com/99269796/205058460-85ac30e9-1b70-4279-894a-879002cc1db9.png">


## Notes
I did keep the "add button" as primary, can override it's CSS and make it look like a link. check below screenshot.
<img width="1216" alt="Screenshot 2022-12-01 at 6 36 01 PM" src="https://user-images.githubusercontent.com/99269796/205060459-8f89e2e7-69ae-4b2e-9bbe-7c2f46595de7.png">
