### PR TITLE
DGJ-732 Contact us in the footer goes to GDX and should go to DJ mailbox

### DIFF
--- a/forms-flow-web/src/components/Footer/Footer.js
+++ b/forms-flow-web/src/components/Footer/Footer.js
@@ -25,7 +25,7 @@ const BCGovFooter = React.memo(() => {
       label: "Copyright",
     },
     {
-      href: "https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111",
+      href: "mailto:digitaljourneys@gov.bc.ca",
       label: "Contact Us",
     },
   ];


### PR DESCRIPTION
## Summary

DGJ-732 Contact us in the footer goes to GDX and should go to DJ mailbox

## Changes
change redirect link to mailto:<DJ email>
