### PR TITLE
feature/DGJ_779-providing-a-list-of-object-keys-to-be-exclude-in-flatting-before-sent-to-ods

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/SendSubmissionToODSDelegate.java
@@ -14,6 +14,9 @@ import org.camunda.bpm.extension.commons.connector.HTTPServiceInvoker;
 import javax.inject.Named;
 import java.io.IOException;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
 
 @Named("SendSubmissionToODSDelegate")
 public class SendSubmissionToODSDelegate extends BaseListener implements JavaDelegate {
@@ -41,6 +44,12 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
         String formUrl = String.valueOf(execution.getVariable("formUrl"));
         String endpoint = String.valueOf(execution.getVariableLocal("endpoint"));
         String httpMethod = String.valueOf(execution.getVariableLocal("httpMethod"));
+        // List of object keys that should not be flatten on send to ODS
+        List<String> flatObjectExclusionList = (List) execution.getVariableLocal("flatObjectExclusionList");
+        // If exceptions not defined, set an empty list
+        if (flatObjectExclusionList == null) {
+            flatObjectExclusionList = new ArrayList<String>();
+        }
 
         LOGGER.warn(String.format("Sending values of form to ODS. Form: %s. ODS Endpoint: %s", formUrl, endpoint));
 
@@ -56,7 +65,7 @@ public class SendSubmissionToODSDelegate extends BaseListener implements JavaDel
         
         String applicationId = String.valueOf(execution.getVariable("applicationId"));
 
-        Map<String, Object> values = formSubmissionService.retrieveFormValues(formUrl, false, true);
+        Map<String, Object> values = formSubmissionService.retrieveFormValues(formUrl, false, true, flatObjectExclusionList);
 
         if (idir != null) {
             values.put("idir", String.valueOf(idir));

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
@@ -176,10 +176,10 @@ public class FormSubmissionService {
     }
 
     public Map<String,Object> retrieveFormValues(String formUrl) throws IOException {
-        return this.retrieveFormValues(formUrl, true, false);
+        return this.retrieveFormValues(formUrl, true, false, new ArrayList<String>());
     }
 
-    public Map<String,Object> retrieveFormValues(String formUrl, boolean withFileInfo, boolean hasNestedObjects) throws IOException {
+    public Map<String,Object> retrieveFormValues(String formUrl, boolean withFileInfo, boolean hasNestedObjects, List<String> flatObjectExclusionList) throws IOException {
         Map<String,Object> fieldValues = new HashMap();
         String submission = readSubmission(formUrl);
         if(StringUtils.isNotEmpty(submission)) {
@@ -204,7 +204,7 @@ public class FormSubmissionService {
                         }
                     }
                 } else {
-                    if (hasNestedObjects && entry.getValue().isObject()) {
+                    if (hasNestedObjects && entry.getValue().isObject() && !flatObjectExclusionList.contains(entry.getKey())) {
                         ObjectNode objectNode = (ObjectNode) entry.getValue();
                         Iterator<Map.Entry<String, JsonNode>> objectElements = objectNode.fields();
 


### PR DESCRIPTION
## Summary

This PR will provide a way to exclude certain objects from faltting on send to ODS. #779 

## Changes
- Reading a list of excluded object keys in `SendSubmissionToODS` listener.
- excluding the objects that are in that list from flatting in `retrieveFormValues` method.
