### PR TITLE
hotfix/add-missing-camunda-deployment-env-for-the-new-doc-url

### DIFF
--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -218,6 +218,11 @@ objects:
                     secretKeyRef:
                       name: forms-flow-ai-config
                       key: ODS_AUTH_TOKEN
+                - name: FORMSFLOW_DOC_API_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: forms-flow-ai-config
+                      key: FORMSFLOW_DOC_API_URL
 
               imagePullPolicy: Always
               livenessProbe:


### PR DESCRIPTION
## Summary

This PR adds a missing doc URL to Camunda deploymentConfig.