### PR TITLE
hotfix/add-missing-documen-url-for-document-dc

### DIFF
--- a/deployment/openshift/forms-flow-documents_dc.yaml
+++ b/deployment/openshift/forms-flow-documents_dc.yaml
@@ -130,11 +130,11 @@ objects:
                   configMapKeyRef:
                     key: WEB_API_BASE_URL
                     name: ${FORMSFLOW_CONFIG_NAME}-config
-              # - name: FORMSFLOW_DOC_API_URL
-              #   valueFrom:
-              #     configMapKeyRef:
-              #       key: FORMSFLOW_DOC_API_URL
-              #       name: ${FORMSFLOW_CONFIG_NAME}-config
+              - name: FORMSFLOW_DOC_API_URL
+                valueFrom:
+                  configMapKeyRef:
+                    key: FORMSFLOW_DOC_API_URL
+                    name: ${FORMSFLOW_CONFIG_NAME}-config
               - name: CHROME_DRIVER_PATH
                 valueFrom:
                   configMapKeyRef:


### PR DESCRIPTION
## Summary

This PR adds a missing env (documentUrl) for the document DC file.