### PR TITLE
DGJ-811 Hide content that has .hidden-in-print class and formio button

### DIFF
--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -24,7 +24,13 @@ export const exportToPdf = ({formId, formName, pdfName}) => {
 export const printToPDF = ({ pdfName, formName }) => {
   // hide block with class .hidden-in-print
   const hiddenInPrint = document.querySelectorAll(".hidden-in-print");
-  hiddenInPrint.forEach((btmElm) => (btmElm.style.display = "none"));
+  let changeElm = [];
+  hiddenInPrint.forEach((elm) => {
+    if (elm.style.display === "" || elm.style.display === "block") {
+      elm.style.display = "none";
+      changeElm.push(elm);
+    }
+  });
   // Hiding the floating buttons during the PDF generation
   const selectors = "button.floatingButton,.formio-component-button";
   const floatingButtons = document.querySelectorAll(selectors);
@@ -33,7 +39,8 @@ export const printToPDF = ({ pdfName, formName }) => {
   exportToPdf({ formId: "formview", pdfName, formName });
   setTimeout(() => {
     floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "visible"));
-    hiddenInPrint.forEach((btmElm) => (btmElm.style.display = "block"));
+    changeElm.forEach((elm) => (elm.style.display = "block"));
+    changeElm = [];
   }, 2000);
 };
 

--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -22,13 +22,18 @@ export const exportToPdf = ({formId, formName, pdfName}) => {
 };
 
 export const printToPDF = ({ pdfName, formName }) => {
+  // hide block with class .hidden-in-print
+  const hiddenInPrint = document.querySelectorAll(".hidden-in-print");
+  hiddenInPrint.forEach((btmElm) => (btmElm.style.display = "none"));
   // Hiding the floating buttons during the PDF generation
-  const floatingButtons = document.querySelectorAll("button.floatingButton");
+  const selectors = "button.floatingButton,.formio-component-button";
+  const floatingButtons = document.querySelectorAll(selectors);
   floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "hidden"));
   toast.success("Downloading...");
   exportToPdf({ formId: "formview", pdfName, formName });
   setTimeout(() => {
     floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "visible"));
+    hiddenInPrint.forEach((btmElm) => (btmElm.style.display = "block"));
   }, 2000);
 };
 


### PR DESCRIPTION
## Summary

DGJ-811 Hide Content that has .hidden-in-print and formio button classes.

## Changes
- Set visibility for the floating and formio buttons.
- Set display property for the content that has class .hidden-in-print. If the content has no visibility, it will occupy space and put a blank page and block in PDF, hence hiding it.


## Notes
NA