### PR TITLE
DGJ-794 Change 1.10 form success page content based on PSA or LDB

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -295,7 +295,7 @@ const doProcessActions = (submission, ownProps) => {
       applicationCreateAPI(data, draft_id ? draft_id : null, (err) => {
         dispatch(setFormSubmissionLoading(false));
         if (!err) {
-          redirectToFormSuccessPage(dispatch, push, form?.path);
+          redirectToFormSuccessPage(dispatch, push, form?.path, submission);
         } else {
           toast.error(
             <Translation>{(t) => t("Submission Failed.")}</Translation>

--- a/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
@@ -260,6 +260,35 @@ export default React.memo(() => {
           </div>
         </>
       );
+    } else if (search.includes(successTypes.COMPLAINT_INTAKE_FORM_1_10_LDB)) {
+      return (
+        <>
+          <span className="success-content-intro">
+            Thank you for submitting your
+            Bullying / Misuse of Authority 
+            Complaint Form (Article 1.10)
+          </span>
+          <div className="success-content-body">
+            <ul>
+              <li>
+                The Liquor Distribution Board (LDB) will notify 
+                your union within 10 days of your complaint.
+              </li>
+              <li>
+                You may ask for assistance from your union 
+                representative either before or after 
+                submitting your complaint.
+              </li>
+              <li>
+                You may also ask your union representative 
+                at any time for an update on the status of 
+                a review or investigation arising from your 
+                complaint.
+              </li>
+            </ul>
+          </div>
+        </>
+      );
     } else if (search.includes(successTypes.COMPLAINT_INTAKE_FORM_1_10)) {
       return (
         <>
@@ -271,13 +300,19 @@ export default React.memo(() => {
           <div className="success-content-body">
             <ul>
               <li>
-                The employer will notify your union within 10 days 
-                of your complaint. You may ask for assistance from 
-                your union representative either before or after 
-                submitting your complaint and may ask your union 
-                representative at any time for an update on the 
-                status of a review or investigation arising from 
-                your complaint.
+                The Public Service Agency (PSA) will notify 
+                your union within 10 days of your complaint.
+              </li>
+              <li>
+                You may ask for assistance from your union 
+                representative either before or after 
+                submitting your complaint.
+              </li>
+              <li>
+                You may also ask your union representative 
+                at any time for an update on the status of 
+                a review or investigation arising from your 
+                complaint.
               </li>
             </ul>
           </div>

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -609,7 +609,7 @@ const doProcessActions = (submission, ownProps) => {
             dispatch(setMaintainBPMFormPagination(true));
 
             dispatch(setDraftSubmission({})); // check "saveDraft" for more detail
-            redirectToFormSuccessPage(dispatch, push, form?.path);
+            redirectToFormSuccessPage(dispatch, push, form?.path, submission);
           }
         } else {
           toast.error(

--- a/forms-flow-web/src/constants/successTypes.js
+++ b/forms-flow-web/src/constants/successTypes.js
@@ -5,14 +5,22 @@ export const SL_REVIEW_SUBMISSION = "SL_REVIEW_SUBMISSION";
 export const SL_REVIEW_RESUBMISSION = "SL_REVIEW_RESUBMISSION";
 export const SL_REVIEW_FINAL_SUBMISSION = "SL_REVIEW_FINAL_SUBMISSION";
 export const COMPLAINT_INTAKE_FORM_1_10 = "1.10_COMPLAINT_INTAKE_FORM";
+export const COMPLAINT_INTAKE_FORM_1_10_LDB = "1.10_COMPLAINT_INTAKE_FORM_LDB";
 
 let submitSuccessPage = {
   seniorleadershipreview: SL_REVIEW_SUBMISSION,
   teleworkagreement: TELEWORK_SUBMISSION,
   "bullying-and-harassment-complaint-article-1-10": COMPLAINT_INTAKE_FORM_1_10,
+  "bullying-and-harassment-complaint-article-1-10-ldb": COMPLAINT_INTAKE_FORM_1_10_LDB,
 };
 
-export const redirectToFormSuccessPage = (dispatch, push, formKey) => {
+export const redirectToFormSuccessPage = (dispatch, push, formKey, submission) => {
+    if (formKey === "bullying-and-harassment-complaint-article-1-10") {
+      if (submission?.data?.pleaseSelectTheUnionYouBelongTo === "bcGeneralEmployeesUnionBcgeu"
+      && submission?.data?.areYouAnEmployeeOfTheLiquorDistributionBoardLdb === "yes") {
+            formKey = `${formKey}-ldb`;
+      }
+    }
     return redirectToSuccessPage(dispatch, push, submitSuccessPage[formKey]);
 };
 

--- a/forms-flow-web/src/constants/successTypes.js
+++ b/forms-flow-web/src/constants/successTypes.js
@@ -7,7 +7,7 @@ export const SL_REVIEW_FINAL_SUBMISSION = "SL_REVIEW_FINAL_SUBMISSION";
 export const COMPLAINT_INTAKE_FORM_1_10 = "1.10_COMPLAINT_INTAKE_FORM";
 export const COMPLAINT_INTAKE_FORM_1_10_LDB = "1.10_COMPLAINT_INTAKE_FORM_LDB";
 
-let submitSuccessPage = {
+const submitSuccessPage = {
   seniorleadershipreview: SL_REVIEW_SUBMISSION,
   teleworkagreement: TELEWORK_SUBMISSION,
   "bullying-and-harassment-complaint-article-1-10": COMPLAINT_INTAKE_FORM_1_10,


### PR DESCRIPTION
## Summary

DGJ-794 Change 1.10 form success page content based on PSA or LDB

## Changes
- Pass the submission parameter in the form redirect, which will help to identify the success page based on submission data.
- Added content for the PSA and LDB conditions for article 1.10 form.

## Screenshots (if applicable)
![Screenshot 2023-01-06 at 5 51 19 PM](https://user-images.githubusercontent.com/99269796/211012601-e22570b0-44e8-4227-b145-1c35f0b3af4d.png)
![Screenshot 2023-01-06 at 5 50 08 PM](https://user-images.githubusercontent.com/99269796/211012623-77f9aba2-55ec-4009-8ac2-c0e99dcec030.png)


## Notes
NA