### PR TITLE
DGJ-845 No email if LDB user don't have bc.gov or bcldb email.

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
@@ -10,6 +10,7 @@ import * as successTypes from "../../../../../constants/successTypes";
 
 export default React.memo(() => {
   const { search } = useLocation();
+  const origin = window.location.origin.toString();
   const isAuthenticated = useSelector((state) => state.user.isAuthenticated);
   if (!isAuthenticated) {
     return <Loading />;
@@ -255,6 +256,40 @@ export default React.memo(() => {
                 <a href="mailto:PSA.SeniorLeadershipReview@gov.bc.ca">
                   PSA.SeniorLeadershipReview@gov.bc.ca
                 </a>
+              </li>
+            </ul>
+          </div>
+        </>
+      );
+    } else if (search.includes(successTypes.COMPLAINT_INTAKE_FORM_1_10_NOEMAIL)) {
+      return (
+        <>
+          <span className="success-content-intro">
+            Thank you for submitting your
+            Bullying / Misuse of Authority 
+            Complaint Form (Article 1.10)
+          </span>
+          <div className="success-content-body">
+            <ul>
+              <li>
+                The Liquor Distribution Board (LDB) will notify 
+                your union within 10 days of your complaint.
+              </li>
+              <li>
+                You may ask for assistance from your union 
+                representative either before or after 
+                submitting your complaint.
+              </li>
+              <li>
+                You may also ask your union representative 
+                at any time for an update on the status of 
+                a review or investigation arising from your 
+                complaint.
+              </li>
+              <li>
+                You may access or download a copy of your 
+                complaint by visiting the  
+                <a href={origin}> Digital Journey portal</a>.
               </li>
             </ul>
           </div>

--- a/forms-flow-web/src/constants/successTypes.js
+++ b/forms-flow-web/src/constants/successTypes.js
@@ -6,19 +6,26 @@ export const SL_REVIEW_RESUBMISSION = "SL_REVIEW_RESUBMISSION";
 export const SL_REVIEW_FINAL_SUBMISSION = "SL_REVIEW_FINAL_SUBMISSION";
 export const COMPLAINT_INTAKE_FORM_1_10 = "1.10_COMPLAINT_INTAKE_FORM";
 export const COMPLAINT_INTAKE_FORM_1_10_LDB = "1.10_COMPLAINT_INTAKE_FORM_LDB";
+export const COMPLAINT_INTAKE_FORM_1_10_NOEMAIL = "1.10_COMPLAINT_INTAKE_FORM_NOEMAIL";
 
 const submitSuccessPage = {
   seniorleadershipreview: SL_REVIEW_SUBMISSION,
   teleworkagreement: TELEWORK_SUBMISSION,
   "bullying-and-harassment-complaint-article-1-10": COMPLAINT_INTAKE_FORM_1_10,
   "bullying-and-harassment-complaint-article-1-10-ldb": COMPLAINT_INTAKE_FORM_1_10_LDB,
+  "bullying-and-harassment-complaint-article-1-10-noemail": COMPLAINT_INTAKE_FORM_1_10_NOEMAIL,
 };
 
 export const redirectToFormSuccessPage = (dispatch, push, formKey, submission) => {
     if (formKey === "bullying-and-harassment-complaint-article-1-10") {
       if (submission?.data?.pleaseSelectTheUnionYouBelongTo === "bcGeneralEmployeesUnionBcgeu"
       && submission?.data?.areYouAnEmployeeOfTheLiquorDistributionBoardLdb === "yes") {
-            formKey = `${formKey}-ldb`;
+            if (submission?.data?.yourPreferredEmailAddress.includes('gov.bc.ca') ||
+            submission?.data?.yourPreferredEmailAddress.includes('bcldb.com')) {
+              formKey = `${formKey}-ldb`;
+            } else {
+              formKey = `${formKey}-noemail`;
+            }
       }
     }
     return redirectToSuccessPage(dispatch, push, submitSuccessPage[formKey]);


### PR DESCRIPTION
## Summary

DGJ-845 No email if LDB user don't have gov.bc.ca or bcldb.com email.

## Changes
Check new field in case of LDB preferredEmail. If it includes gov.bc.ca or bcldb.com domain then we will continue as old one. If not then we will show different detail in success page and not send PDF attachment in email (this one will handle in camunda).


## Notes
NA