### PR TITLE
DGJ-860 print pdf not render properly for the task tab

### DIFF
--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -22,6 +22,13 @@ export const exportToPdf = ({formId, formName, pdfName}) => {
 };
 
 export const printToPDF = ({ pdfName, formName }) => {
+  let maxWidth = '1440px';
+  if (window.location.href.includes('/task/')) {
+    maxWidth = '1920px';
+  }
+  const appContainer = document.querySelectorAll("div.app-container.container")[0];
+  appContainer.style.maxWidth = maxWidth;
+  appContainer.style.minWidth = maxWidth;
   // hide block with class .hidden-in-print
   const hiddenInPrint = document.querySelectorAll(".hidden-in-print");
   let changeElm = [];
@@ -41,6 +48,8 @@ export const printToPDF = ({ pdfName, formName }) => {
     floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "visible"));
     changeElm.forEach((elm) => (elm.style.display = "block"));
     changeElm = [];
+    appContainer.style.maxWidth = '';
+    appContainer.style.minWidth = '';
   }, 2000);
 };
 


### PR DESCRIPTION
## Summary

DGJ-860 Print PDF not render properly for task tab.

## Changes
In the PDF function that generate PDF on the frontend. I have added width of the main container. min and max 1440 for all the other page and for /task/ tab it will be 1920px. As in the task tab we have sidebar hence it render using only 70% of page and that's why it looks different than other page.

Set width before PDF generate and revert it once PDF generated.


## Notes
I have set value in the initial as it add inline stylesheet. and at the end set '' (blank string) to remove the attached inline stylesheet. This setting works well.