### PR TITLE
feature/DGJ_781-bceid_integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ instance/*
 !instance/.gitignore
 .webassets-cache
 .env
+.env.local
+.env.dev
 
 ### Flask.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/forms-flow-api/src/formsflow_api/models/employee_data_bceid.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data_bceid.py
@@ -1,0 +1,6 @@
+class EmployeeDataBceid():
+  def __init__(self, data):
+   self.displayName = data["first_name"] + " " + data["last_name"]
+   self.firstName = data["first_name"]
+   self.lastName = data["last_name"]
+   self.email = data["email"]

--- a/forms-flow-api/src/formsflow_api/resources/employeeData.py
+++ b/forms-flow-api/src/formsflow_api/resources/employeeData.py
@@ -24,14 +24,17 @@ class EmployeeDataResource(Resource):
         """Get the employee data based on bcGov guid."""
         try:
             GUID = g.token_info.get("bcgovguid")
+            BCeID = g.token_info.get("bceid_user_guid")
         except:
             return {"message": "Something went wrong!"}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-        if not GUID:
-            return {"message": "user had no guid!"}, HTTPStatus.NOT_FOUND
-
         try:
-            userData = EmployeeDataService.get_employee_data_from_bcgov(GUID)
+            if BCeID:
+                userData = EmployeeDataService.get_employee_data_from_bceid()
+            elif GUID:
+                userData = EmployeeDataService.get_employee_data_from_bcgov(GUID)
+            else:
+                return {"message": "user idp is not any of IDIR or BCeID!"}, HTTPStatus.NOT_FOUND
         except BusinessException as err:
             current_app.logger.warning(err.error)
             return err.error, err.status_code

--- a/forms-flow-api/src/formsflow_api/services/employeeDataService.py
+++ b/forms-flow-api/src/formsflow_api/services/employeeDataService.py
@@ -2,9 +2,10 @@ import requests
 import re
 from urllib.parse import unquote
 from http import HTTPStatus
-from flask import current_app
+from flask import current_app, g
 from formsflow_api_utils.exceptions import BusinessException
 from formsflow_api.models.employee_data import EmployeeData
+from formsflow_api.models.employee_data_bceid import EmployeeDataBceid
 
 class EmployeeDataService: 
     
@@ -33,7 +34,19 @@ class EmployeeDataService:
       raise BusinessException(
           {"message": "No user data found"}, HTTPStatus.NOT_FOUND
         )
-
+    
+    @staticmethod
+    def get_employee_data_from_bceid():
+      email = g.token_info.get("email")
+      family_name = g.token_info.get("family_name")
+      given_name = g.token_info.get("given_name")
+      data = {
+        "first_name": given_name,
+        "last_name": family_name,
+        "email": email
+      }
+      emp_data = EmployeeDataBceid(data)
+      return emp_data.__dict__
 
     @staticmethod
     def get_employee_names(args):

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/UserGroupAssignmentListener.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/UserGroupAssignmentListener.java
@@ -86,6 +86,7 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
 
     private void syncFormVariables(DelegateExecution execution) throws IOException {
         String managerEmail = String.valueOf(execution.getVariables().get("managerEmail"));
+        String managerUsername = managerEmail + "_idir";
         String groupPathToBeAdded = String.valueOf(this.groupPath.getValue(execution));
         
         if (managerEmail == null || managerEmail.isEmpty() || 
@@ -103,16 +104,16 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
         }
 
         try {
-            UserRepresentation userRepresentation = getUser(managerEmail, realmResource);
+            UserRepresentation userRepresentation = getUser(managerUsername, realmResource);
             if (userRepresentation == null) {
                 // Create a new user with this email
-                createKeycloakUser(managerEmail, realmResource);
+                createKeycloakUser(managerEmail, managerUsername, realmResource);
                 
                 // Get the created user
-                userRepresentation = getUser(managerEmail, realmResource);
+                userRepresentation = getUser(managerUsername, realmResource);
                 
                 if (userRepresentation == null) {
-                    System.out.println("User was not found after creation: " + managerEmail);
+                    System.out.println("User was not found after creation: " + managerUsername);
                     return;
                 }
             }
@@ -134,14 +135,14 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
         }
     }
 
-    private UserRepresentation getUser(String managerEmail, RealmResource realmResource) throws RuntimeException {
-        List<UserRepresentation> userRepresentations = realmResource.users().search(managerEmail, 0, 1);
+    private UserRepresentation getUser(String managerUsername, RealmResource realmResource) throws RuntimeException {
+        List<UserRepresentation> userRepresentations = realmResource.users().search(managerUsername, 0, 1);
 
         if (userRepresentations.size() > 1) {
-            System.out.println("More than one user found for email: " + managerEmail);
-            throw new RuntimeException("More than one user found for email: " + managerEmail);
+            System.out.println("More than one user found for username: " + managerUsername);
+            throw new RuntimeException("More than one user found for username: " + managerUsername);
         } else if (userRepresentations.size() == 0) { 
-            System.out.println("No user found by email: " + managerEmail);
+            System.out.println("No user found by username: " + managerUsername);
             return null;
         } 
         
@@ -149,9 +150,9 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
         return userRepresentation;
     }
 
-    private void createKeycloakUser(String managerEmail, RealmResource realmResource) throws RuntimeException {
+    private void createKeycloakUser(String managerEmail, String managerUsername, RealmResource realmResource) throws RuntimeException {
         UserRepresentation userRepresentation = new UserRepresentation();
-        userRepresentation.setUsername(managerEmail);
+        userRepresentation.setUsername(managerUsername);
         userRepresentation.setEmail(managerEmail);
         userRepresentation.setEnabled(true) ;
         Response response = realmResource.users().create(userRepresentation);
@@ -191,6 +192,6 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
             return;
         }
         userResource.joinGroup(groupToBeAdded.getId());
-        System.out.println("group: " + groupToBeAdded.getPath() + " was successfully added to user: " + user.getEmail());
+        System.out.println("group: " + groupToBeAdded.getPath() + " was successfully added to user: " + user.getUsername());
     }
 }

--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -36,6 +36,7 @@ import {
   MULTITENANCY_ENABLED,
   DRAFT_ENABLED,
   DRAFT_POLLING_RATE,
+  STAFF_DESIGNER,
 } from "../../constants/constants";
 import Loading from "../../containers/Loading";
 import SubmissionError from "../../containers/SubmissionError";
@@ -158,23 +159,25 @@ const View = React.memo((props) => {
     };
   });
 
-  let formAccessInterval = null;
-  useEffect(() => {
-    formAccessInterval = setInterval(() => {
-      /* check formRef before calling function of formio */
-      if (formRef.current !== null) {
-        const formSupportedIdentityProviders = getFormSupportedIdentityProviders(
-          formRef.current?.formio, 
-          FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME, formAccessInterval);
-        if (Array.isArray(formSupportedIdentityProviders)) {
-          setHasFormAccess(hasUserAccessToForm(formSupportedIdentityProviders, user.username));
+  if (!user.role.some(el => el === STAFF_DESIGNER)) {
+    let formAccessInterval = null;
+    useEffect(() => {
+      formAccessInterval = setInterval(() => {
+        /* check formRef before calling function of formio */
+        if (formRef.current !== null) {
+          const formSupportedIdentityProviders = getFormSupportedIdentityProviders(
+            formRef.current?.formio, 
+            FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME, formAccessInterval);
+          if (Array.isArray(formSupportedIdentityProviders)) {
+            setHasFormAccess(hasUserAccessToForm(formSupportedIdentityProviders, user.username));
+          }
         }
-      }
-    }, 1000);
-    return () => {
-      clearInterval(formAccessInterval);
-    };
-  });
+      }, 1000);
+      return () => {
+        clearInterval(formAccessInterval);
+      };
+    });
+  }
 
   if (isActive || isPublicStatusLoading) {
     return (

--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -42,8 +42,11 @@ import SubmissionError from "../../containers/SubmissionError";
 // eslint-disable-next-line no-unused-vars
 import SavingLoading from "../Loading/SavingLoading";
 import { redirectToFormSuccessPage } from "../../constants/successTypes";
-import { convertFormLinksToOpenInNewTabs } from "../../helper/formUtils";
+import { convertFormLinksToOpenInNewTabs, getFormSupportedIdentityProviders, 
+  hasUserAccessToForm } from "../../helper/formUtils";
 import { printToPDF } from "../../services/PdfService";
+import MessageModal from "../../containers/MessageModal";
+import { FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME } from "../../constants/formConstants";
 
 const View = React.memo((props) => {
   const { t } = useTranslation();
@@ -79,6 +82,9 @@ const View = React.memo((props) => {
   const { formId } = useParams();
   const [poll, setPoll] = useState(DRAFT_ENABLED);
   const exitType = useRef("UNMOUNT");
+
+  const [hasFormAccess, setHasFormAccess] = useState(true);
+
   const {
     isAuthenticated,
     submission,
@@ -88,6 +94,7 @@ const View = React.memo((props) => {
     errors,
     options,
     form: { form, isActive, url },
+    user,
   } = props;
   const dispatch = useDispatch();
 
@@ -151,6 +158,24 @@ const View = React.memo((props) => {
     };
   });
 
+  let formAccessInterval = null;
+  useEffect(() => {
+    formAccessInterval = setInterval(() => {
+      /* check formRef before calling function of formio */
+      if (formRef.current !== null) {
+        const formSupportedIdentityProviders = getFormSupportedIdentityProviders(
+          formRef.current?.formio, 
+          FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME, formAccessInterval);
+        if (Array.isArray(formSupportedIdentityProviders)) {
+          setHasFormAccess(hasUserAccessToForm(formSupportedIdentityProviders, user.username));
+        }
+      }
+    }, 1000);
+    return () => {
+      clearInterval(formAccessInterval);
+    };
+  });
+
   if (isActive || isPublicStatusLoading) {
     return (
       <div data-testid="loading-view-component">
@@ -207,6 +232,14 @@ const View = React.memo((props) => {
       } */}
       <div className="d-flex align-items-center justify-content-between">
         <div className="main-header">
+          <MessageModal
+            modalOpen={!hasFormAccess}
+            title="Form Access Error"
+            message={"You do not have access to this form!"}
+            onConfirm={() => {
+              window.location.replace(`${window.location.origin}/form`);
+            }}
+          />
           <SubmissionError
             modalOpen={props.submissionError.modalOpen}
             message={props.submissionError.message}

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -52,6 +52,7 @@ import {
   MULTITENANCY_ENABLED,
   DRAFT_ENABLED,
   DRAFT_POLLING_RATE,
+  STAFF_DESIGNER,
 } from "../../../constants/constants";
 import useInterval from "../../../customHooks/useInterval";
 import selectApplicationCreateAPI from "./apiSelectHelper";
@@ -408,23 +409,25 @@ const View = React.memo((props) => {
     };
   });
 
-  let formAccessInterval = null;
-  useEffect(() => {
-    formAccessInterval = setInterval(() => {
-      /* check formRef before calling function of formio */
-      if (formRef.current !== null) {
-        const formSupportedIdentityProviders = getFormSupportedIdentityProviders(
-          formRef.current?.formio, 
-          FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME, formAccessInterval);
-        if (Array.isArray(formSupportedIdentityProviders)) {
-          setHasFormAccess(hasUserAccessToForm(formSupportedIdentityProviders, user.username));
+  if (!user.role.some(el => el === STAFF_DESIGNER)) {
+    let formAccessInterval = null;
+    useEffect(() => {
+      formAccessInterval = setInterval(() => {
+        /* check formRef before calling function of formio */
+        if (formRef.current !== null) {
+          const formSupportedIdentityProviders = getFormSupportedIdentityProviders(
+            formRef.current?.formio, 
+            FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME, formAccessInterval);
+          if (Array.isArray(formSupportedIdentityProviders)) {
+            setHasFormAccess(hasUserAccessToForm(formSupportedIdentityProviders, user.username));
+          }
         }
-      }
-    }, 1000);
-    return () => {
-      clearInterval(formAccessInterval);
-    };
-  });
+      }, 1000);
+      return () => {
+        clearInterval(formAccessInterval);
+      };
+    });
+  }
 
   if (isActive || isPublicStatusLoading || formStatusLoading) {
     return (

--- a/forms-flow-web/src/constants/formConstants.js
+++ b/forms-flow-web/src/constants/formConstants.js
@@ -6,3 +6,5 @@ export const FORM_NAMES = {
     complaintform: 'Bullying and Harassment Complaint Form',
     complaintform110: 'Bullying / Misuse of Authority Complaint'
   };
+
+export const FORM_SUPPORTED_IDENTITY_PROVIDERS_FIELD_NAME = 'formSupportedIdentityProviders';

--- a/forms-flow-web/src/containers/MessageModal.jsx
+++ b/forms-flow-web/src/containers/MessageModal.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import { useTranslation } from "react-i18next";
+
+const MessageModal = React.memo((props) => {
+  const { modalOpen = false, onConfirm, message, title } = props;
+  const { t } = useTranslation();
+  return (
+    <>
+      <Modal show={modalOpen}>
+        <Modal.Header>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{message}</Modal.Body>
+        <Modal.Footer>
+          <Button type="button" className="btn btn-default" onClick={onConfirm}>
+            {t("Ok")}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+});
+
+export default MessageModal;

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -44,8 +44,33 @@ const enableFormButton = (formio, enableButtonInterval, buttonKey, onClick) => {
   }
 };
 
+const getFormSupportedIdentityProviders = (formio, key, interval) => {
+  let formSupportedIdentityProviders = [];
+  if (formio) {
+    clearInterval(interval);
+    formio.everyComponent((component) => {
+      if (component.component.key === key){
+        // Parse identity providers string (e.g., idir,bceid or idir) into an array
+        formSupportedIdentityProviders = component.component?.defaultValue?.replace(/\s/g, '')?.split(",");
+      }
+    });
+  }
+  return formSupportedIdentityProviders;
+};
+
+const hasUserAccessToForm = (formSupportedIdentityProviders, username) => {
+  /* Usernames have postfix with the name the identity provider the user logged in with
+   * for example a user that was logged in by IDIR has a username of "username_idir", one logged in with BCeID has username of "username_bceid"
+  */
+  // Parse the identity provider part of the user's username
+  const userIdentityProvider = username.split("_")[(username.split("_")).length - 1];
+  return formSupportedIdentityProviders.some(el => el === userIdentityProvider);
+};
+
 export {
   convertFormLinksToOpenInNewTabs,
   scrollToErrorOnValidation,
   enableFormButton,
+  getFormSupportedIdentityProviders,
+  hasUserAccessToForm
 };


### PR DESCRIPTION
## Summary

This PR integrates BCeID as a new IDP (identity provider, e.g., IDIR, BCeid, or BCSC). #781 

## Changes
- Keycloak supports users with duplicate emails.
- Usernames are no longer rely on emails, instead rely on a unique format.
  - IDIR (users will have unique emails): `email_idir`
  - BCeID (users may not have unique emails, you can have two accounts with the same email): `bceidUsername_bceid`
- Manager task assignment in Camunda updated to support the new unique username in IDIR submissions
- Form access was added. A hidden field in each form (`formSupportedIdentityProviders`) can now determine which users log in with which IDPs have access to that form. The form designer will have access to all forms while users whose IDPs are not allowed for a certain form will get a message and will be redirected to the form list page.
- Employee.me endpoint was updated to support users that log in with BCeID.


## Notes
- Documentation for how a form designer can edit `formSupportedIdentityProviders` will be added before pushing to the main branch.
- There are many changes in Keycloak configurations that are not included in the code. Will demo in a call.