### PR TITLE
DGJ_888-extract_bceid_last_name

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/employee_data.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data.py
@@ -5,7 +5,7 @@ class EmployeeData():
   # data: Response retrieved from the ODS
   # Spec of possible values can be found at: https://analytics-testapi.psa.gov.bc.ca/apiserver/api.rst#Datamart_Telework_employee_demo
   def __init__(self, data):
-   self.displayName = data["first_name"] + " " + data["last_name"]
+   self.displayName = " ".join(filter(None, (data["first_name"], data["last_name"])))
    self.name = data["name"]
    self.firstName = data["first_name"]
    self.lastName = data["last_name"]

--- a/forms-flow-api/src/formsflow_api/models/employee_data_bceid.py
+++ b/forms-flow-api/src/formsflow_api/models/employee_data_bceid.py
@@ -1,6 +1,6 @@
 class EmployeeDataBceid():
   def __init__(self, data):
-   self.displayName = data["first_name"] + " " + data["last_name"]
+   self.displayName = " ".join(filter(None, (data["first_name"], data["last_name"])))
    self.firstName = data["first_name"]
    self.lastName = data["last_name"]
    self.email = data["email"]

--- a/forms-flow-api/src/formsflow_api/services/employeeDataService.py
+++ b/forms-flow-api/src/formsflow_api/services/employeeDataService.py
@@ -38,8 +38,18 @@ class EmployeeDataService:
     @staticmethod
     def get_employee_data_from_bceid():
       email = g.token_info.get("email")
-      family_name = g.token_info.get("family_name")
       given_name = g.token_info.get("given_name")
+      family_name = g.token_info.get("family_name")
+
+      # BCeID currently provides user's display_name under given_name attribute. 
+      # Therefore we need to manually extract given_name and family_name from it.
+      if (given_name and not family_name):
+        # split the first word into given name and the rest into family name.
+        names = given_name.split(" ", 1)
+        given_name = names[0]
+        if (len(names) > 1):
+          family_name = names[1]
+      
       data = {
         "first_name": given_name,
         "last_name": family_name,


### PR DESCRIPTION
## Summary

This PR fixes the issue with BCeID the last name being automatically extracted from `display_name`.

Context: BCeID only provides `display_name` and not providing first_name and last_name separately. `display_name` is passed as the first_name through the Keycloak. To fix that, as a workaround employee.me endpoint split them and pass them separately to the FE.

## Changes
- Extracting first_name and last_name from BCeID display_name.
- Also updated employeeData models to not break if either first_name or last_name is null during the creation of display_name.

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
Another issue that was fixed as part of this PR, through Keycloak Configs, was the initial BCeID prompt to update their info including first and last names. To force Keycloak to not to show that form (listed in the image below), a new login flow was assigned to BCeID identity Provider (listed in the image below)

<img width="747" alt="Screenshot 2023-02-02 at 11 03 41 AM" src="https://user-images.githubusercontent.com/77303486/217148400-d9d20d3b-fe32-483c-a5cb-7a44822af4ae.png">

<img width="2487" alt="Screenshot 2023-02-06 at 8 28 35 PM" src="https://user-images.githubusercontent.com/77303486/217148495-de6afa5a-2359-4e4f-ab5b-ae29c362b5d2.png">
