### PR TITLE
hotfix/revert-Snyk-camunda-update

### DIFF
--- a/forms-flow-bpm/pom.xml
+++ b/forms-flow-bpm/pom.xml
@@ -24,9 +24,8 @@
 
 		<!-- versions -->
 		<version.camundaKeycloak>2.2.3</version.camundaKeycloak>
-    <version.camunda>7.18.0</version.camunda><!-- 7.15.0 - 7.17.0 -->
+    <version.camunda>7.17.0</version.camunda><!-- 7.15.0 - 7.17.0 -->
 		<version.camundaConnect>1.5.6</version.camundaConnect><!-- 1.5.0 -->
-		
 		<version.camundaMail>1.3.0</version.camundaMail><!-- 1.3.0 -->
 		<version.springBoot>2.6.8</version.springBoot><!-- 2.4.8 - 2.6.4 -->
 		<version.springSecurityOauth2>2.6.8</version.springSecurityOauth2><!-- 


### PR DESCRIPTION
## Summary

This PR revert one of the Snyk PRs that updated Camunda version. Unfortunately that caused build failure and there is not an easy way to fix. I guess, we should wait for forms-flow-ai to update the whole bpm.