### PR TITLE
hotfix/pattroni-securityContext

### DIFF
--- a/deployment/openshift/Databases/patroni-deployment.yaml
+++ b/deployment/openshift/Databases/patroni-deployment.yaml
@@ -175,6 +175,8 @@ objects:
             value: 0.0.0.0:5432
           - name: PATRONI_RESTAPI_LISTEN
             value: 0.0.0.0:8008
+          securityContext:
+            allowPrivilegeEscalation: true
           ports:
           - containerPort: 8008
             protocol: TCP


### PR DESCRIPTION
## Summary

This PR adds a `securityContext` to the Patroni deployment file to be compatible with the new OpenShift v4.11.

## Note

This fix has already been applied through the OpenShift console, adding it to the file to capture the state of this file.