### PR TITLE
DGJ_849-redash_and_redis_updated

### DIFF
--- a/deployment/openshift/Databases/redis-cluster.dc.yaml
+++ b/deployment/openshift/Databases/redis-cluster.dc.yaml
@@ -218,7 +218,7 @@ parameters:
     description: Redis Image Tag
     displayName: Image Tag
     required: true
-    value: 6.0.9-alpine
+    value: 6.2.10-alpine
   - name: CPU_REQUEST
     description: Starting amount of CPU the container can use.
     displayName: CPU Request

--- a/forms-flow-analytics/docker-compose.yml
+++ b/forms-flow-analytics/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3.7"
 
 x-redash-service: &redash-service
-  image: formsflow/redash:10.1.2
+  image: formsflow/redash:10.1.4
   depends_on:
       - postgres
       - redis
@@ -38,7 +38,7 @@ services:
     depends_on:
       - server
   redis:
-    image: redis:6-alpine
+    image: redis:6.2.10-alpine
     restart: always
   postgres:
     image: postgres:9.6-alpine


### PR DESCRIPTION
## Summary

This PR updates Redash and Redis versions to the latest compatible versions. #849 

## Changes
- Redash was updated to its latest version in docker-compose. It already was updated in the Openshift and all the envs.
- Redis was updated in its Openshift config and docker-compose files to the latest compatible version. Already updated in the Openshift and all the envs.

