### PR TITLE
DGJ_908-info-modal-component

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -86,6 +86,9 @@ const View = React.memo((props) => {
 
   const [hasFormAccess, setHasFormAccess] = useState(true);
 
+  const [showPopup, setShowPopup] = useState(false);
+  const [popupData, setPopupData] = useState();
+
   const {
     isAuthenticated,
     submission,
@@ -214,6 +217,10 @@ const View = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
         toast.error(evt.error);
         break;
+      case CUSTOM_EVENT_TYPE.POPUP:
+        setPopupData({ title: evt.title, body: evt.body });
+        setShowPopup(true);
+        break;
       default:
         return;
     }
@@ -243,6 +250,14 @@ const View = React.memo((props) => {
               window.location.replace(`${window.location.origin}/form`);
             }}
           />
+          {popupData && (
+            <MessageModal
+              modalOpen={showPopup}
+              title={popupData.title}
+              message={popupData.body}
+              onConfirm={() => setShowPopup(false)}
+            />
+          )}
           <SubmissionError
             modalOpen={props.submissionError.modalOpen}
             message={props.submissionError.message}

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -430,12 +430,12 @@ const View = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.PRINT_PDF:
         printToPDF({ formName: evt.formName, pdfName: evt.pdfName });
         break;
+      case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
+        toast.error(evt.error);
+        break;
       case CUSTOM_EVENT_TYPE.POPUP:
         setPopupData({ title: evt.title, body: evt.body });
         setShowPopup(true);
-        break;
-      case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
-        toast.error(evt.error);
         break;
       default:
         return;
@@ -479,7 +479,6 @@ const View = React.memo((props) => {
               window.location.replace(`${window.location.origin}/form`);
             }}
           />
-          
           {popupData && 
             <MessageModal
               modalOpen={showPopup}
@@ -519,7 +518,7 @@ const View = React.memo((props) => {
       </div>
       <Errors errors={errors} />
       <LoadingOverlay
-        active={isFormSubmissionLoading || employeeData.loading}
+        // active={isFormSubmissionLoading || employeeData.loading}
         spinner
         // text={<Translation>{(t) => t("Loading...")}</Translation>}
         text={

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -118,6 +118,9 @@ const View = React.memo((props) => {
   const [defaultVals, setDefaultVals] = useState({});
   
   const [hasFormAccess, setHasFormAccess] = useState(false);
+  
+  const [showPopup, setShowPopup] = useState(false);
+  const [popupData, setPopupData] = useState();
 
   const {
     isAuthenticated,
@@ -427,6 +430,10 @@ const View = React.memo((props) => {
       case CUSTOM_EVENT_TYPE.PRINT_PDF:
         printToPDF({ formName: evt.formName, pdfName: evt.pdfName });
         break;
+      case CUSTOM_EVENT_TYPE.POPUP:
+        setPopupData({ title: evt.title, body: evt.body });
+        setShowPopup(true);
+        break;
       case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
         toast.error(evt.error);
         break;
@@ -472,6 +479,14 @@ const View = React.memo((props) => {
               window.location.replace(`${window.location.origin}/form`);
             }}
           />
+          
+          {popupData && 
+            <MessageModal
+              modalOpen={showPopup}
+              title={popupData.title}
+              message={popupData.body}
+              onConfirm={() => setShowPopup(false)}
+            />}
           <SubmissionError
             modalOpen={props.submissionError.modalOpen}
             message={props.submissionError.message}

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -518,7 +518,7 @@ const View = React.memo((props) => {
       </div>
       <Errors errors={errors} />
       <LoadingOverlay
-        // active={isFormSubmissionLoading || employeeData.loading}
+        active={isFormSubmissionLoading || employeeData.loading}
         spinner
         // text={<Translation>{(t) => t("Loading...")}</Translation>}
         text={

--- a/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
@@ -7,4 +7,5 @@ export const CUSTOM_EVENT_TYPE = {
   SAVE_DRAFT: "saveDraft",
   PRINT_PDF: "printPDF",
   ERROR_CUSTOM_VALIDATION: "errorCustomValidation",
+  POPUP: "popup",
 };

--- a/forms-flow-web/src/containers/MessageModal.jsx
+++ b/forms-flow-web/src/containers/MessageModal.jsx
@@ -12,7 +12,9 @@ const MessageModal = React.memo((props) => {
         <Modal.Header>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <Modal.Body>{message}</Modal.Body>
+        <Modal.Body>
+          <div dangerouslySetInnerHTML={{ __html: message }} />
+        </Modal.Body>
         <Modal.Footer>
           <Button type="button" className="btn btn-default" onClick={onConfirm}>
             {t("Ok")}

--- a/forms-flow-web/src/containers/MessageModal.jsx
+++ b/forms-flow-web/src/containers/MessageModal.jsx
@@ -9,9 +9,9 @@ const MessageModal = React.memo((props) => {
   return (
     <>
       <Modal show={modalOpen}>
-        <Modal.Header>
+        {title && <Modal.Header>
           <Modal.Title>{title}</Modal.Title>
-        </Modal.Header>
+        </Modal.Header>}
         <Modal.Body>
           <div dangerouslySetInnerHTML={{ __html: message }} />
         </Modal.Body>

--- a/forms-flow-web/src/formComponents/TextArea/index.js
+++ b/forms-flow-web/src/formComponents/TextArea/index.js
@@ -1,0 +1,31 @@
+import { Components } from "react-formio";
+
+const TextArea = Components.components.textarea;
+
+/**
+ * Overrides the default TextArea component
+ *
+ * TextArea will support tooltip that is displayed as a popup
+ * 
+ */
+export default class DGJTextAreaComponent extends TextArea {
+  attach(element) {
+    const webForm = this;
+    const tooltipInfoButton = element?.children[0]?.children[0];
+    const tooltipHtmlText = webForm.component.tooltip;
+    // By contract, form designer should add the following 
+    // popup html comment in the tooltip text to force it to be opened as a popup
+    const isTooltipPopup = tooltipHtmlText.includes("<!-- popup -->");
+    if (isTooltipPopup && tooltipInfoButton) {
+      // Removing tooltip text before popup to disable the default tooltip display
+      tooltipInfoButton.setAttribute("data-tooltip", "");
+      tooltipInfoButton.addEventListener("click", function () {
+        webForm.emit("customEvent", {
+          type: "popup",
+          body: tooltipHtmlText,
+        });
+      });
+    }
+    return super.attach(element);
+  }
+}

--- a/forms-flow-web/src/formComponents/TextField/index.js
+++ b/forms-flow-web/src/formComponents/TextField/index.js
@@ -1,0 +1,31 @@
+import { Components } from "react-formio";
+
+const TextField = Components.components.textfield;
+
+/**
+ * Overrides the default TextField component
+ *
+ * TextField will support tooltip that is displayed as a popup
+ * 
+ */
+export default class DGJTextFieldComponent extends TextField {
+  attach(element) {
+    const webForm = this;
+    const tooltipInfoButton = element?.children[0]?.children[0];
+    const tooltipHtmlText = webForm.component.tooltip;
+    // By contract, form designer should add the following 
+    // popup html comment in the tooltip text to force it to be opened as a popup
+    const isTooltipPopup = tooltipHtmlText.includes("<!-- popup -->");
+    if (isTooltipPopup && tooltipInfoButton) {
+      // Removing tooltip text before popup to disable the default tooltip display
+      tooltipInfoButton.setAttribute("data-tooltip", "");
+      tooltipInfoButton.addEventListener("click", function () {
+        webForm.emit("customEvent", {
+          type: "popup",
+          body: tooltipHtmlText,
+        });
+      });
+    }
+    return super.attach(element);
+  }
+}

--- a/forms-flow-web/src/index.js
+++ b/forms-flow-web/src/index.js
@@ -18,6 +18,8 @@ import RemoteSelect from "./formComponents/RemoteSelect";
 import MinistrySelect from "./formComponents/MinistrySelect";
 import UploadProvider from "./formComponents/UploadProvider";
 import PanelComponent from "./formComponents/Panel";
+import TextFieldComponent from "./formComponents/TextField";
+import TextAreaComponent from "./formComponents/TextArea";
 
 // disable react-dev-tools for this project
 if (typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === "object") {
@@ -44,16 +46,18 @@ import("formsflow-formio-custom-elements/dist/customformio-ex").then(
 );
 
 // Add custom file upload provider
-Formio.Providers.addProvider('storage', 'digital-journeys', UploadProvider);
+Formio.Providers.addProvider("storage", "digital-journeys", UploadProvider);
 
 // Override the default file upload component with the custom one to provide
 // reasonable default values
-Components.setComponent('file', DGJFileUpload);
-Components.setComponent('panel', PanelComponent);
+Components.setComponent("file", DGJFileUpload);
+Components.setComponent("panel", PanelComponent);
+Components.setComponent("textfield", TextFieldComponent);
+Components.setComponent("textarea", TextAreaComponent);
 
 // Adding two remote select components extending original formio Select
-Components.addComponent('remoteSelect', RemoteSelect);
-Components.addComponent('ministrySelect', MinistrySelect);
+Components.addComponent("remoteSelect", RemoteSelect);
+Components.addComponent("ministrySelect", MinistrySelect);
 
 ReactDOM.render(
   <FlagsProvider features={featureFlags}>


### PR DESCRIPTION
## Summary
This PR introduces a reusable popup component that can be triggered by a custom button in the forms. In addition, textField and textArea components in the Formio were extended to support a tooltip that can trigger that popup component.

The popup component can receive `title` in text and `body` in text/HTML format.

This PR completes two tickets #907  and #908 

## Changes
- View and Draft pages now support a reusable modal component that can be triggered by a custom event
- `textField` and `textArea` components were extended to enable tooltips to open in the popup by passing a special HTML comment in the first line of the tooltip text. `<!-- popup -->`

## Screenshots (if applicable)
<img width="1766" alt="Screenshot 2023-02-28 at 1 55 31 PM" src="https://user-images.githubusercontent.com/77303486/221990450-fe25a50f-1db7-4e5d-a512-4943c87853c7.png">



