### PR TITLE
hotfix/DGJ_908-info-modal-component

### DIFF
--- a/forms-flow-web/src/formComponents/TextArea/index.js
+++ b/forms-flow-web/src/formComponents/TextArea/index.js
@@ -13,13 +13,20 @@ export default class DGJTextAreaComponent extends TextArea {
     const webForm = this;
     const tooltipInfoButton = element?.children[0]?.children[0];
     const tooltipHtmlText = webForm.component.tooltip;
-    // By contract, form designer should add the following 
+    // By contract, form designer should add the following
     // popup html comment in the tooltip text to force it to be opened as a popup
     const isTooltipPopup = tooltipHtmlText.includes("<!-- popup -->");
     if (isTooltipPopup && tooltipInfoButton) {
       // Removing tooltip text before popup to disable the default tooltip display
       tooltipInfoButton.setAttribute("data-tooltip", "");
-      tooltipInfoButton.addEventListener("click", function () {
+      // Replacing the tooltipButton with a clone to make sure all the previous 
+      // eventListeners are removed except the popup
+      let newTooltipInfoButton = tooltipInfoButton.cloneNode(true);
+      tooltipInfoButton.parentNode.replaceChild(
+        newTooltipInfoButton,
+        tooltipInfoButton
+      );
+      newTooltipInfoButton.addEventListener("click", function () {
         webForm.emit("customEvent", {
           type: "popup",
           body: tooltipHtmlText,

--- a/forms-flow-web/src/formComponents/TextField/index.js
+++ b/forms-flow-web/src/formComponents/TextField/index.js
@@ -6,20 +6,27 @@ const TextField = Components.components.textfield;
  * Overrides the default TextField component
  *
  * TextField will support tooltip that is displayed as a popup
- * 
+ *
  */
 export default class DGJTextFieldComponent extends TextField {
   attach(element) {
     const webForm = this;
     const tooltipInfoButton = element?.children[0]?.children[0];
     const tooltipHtmlText = webForm.component.tooltip;
-    // By contract, form designer should add the following 
+    // By contract, form designer should add the following
     // popup html comment in the tooltip text to force it to be opened as a popup
     const isTooltipPopup = tooltipHtmlText.includes("<!-- popup -->");
     if (isTooltipPopup && tooltipInfoButton) {
       // Removing tooltip text before popup to disable the default tooltip display
       tooltipInfoButton.setAttribute("data-tooltip", "");
-      tooltipInfoButton.addEventListener("click", function () {
+      // Replacing the tooltipButton with a clone to make sure all the 
+      // previous eventListeners are removed except the popup
+      let newTooltipInfoButton = tooltipInfoButton.cloneNode(true);
+      tooltipInfoButton.parentNode.replaceChild(
+        newTooltipInfoButton,
+        tooltipInfoButton
+      );
+      newTooltipInfoButton.addEventListener("click", function () {
         webForm.emit("customEvent", {
           type: "popup",
           body: tooltipHtmlText,


### PR DESCRIPTION
## Summary

This Hotfix fixes the issue with tooltip info buttons supporting popups. Sometimes their previous event listeners were triggered which means a tooltip shows the tooltip when hovered as opposed to only showing the popup when clicked.

## Changes
- Popup tooltips were cloned and replaced to drop all the previous eventListneres

## Screenshots (if applicable)
<img width="518" alt="Screenshot 2023-03-01 at 9 41 05 AM" src="https://user-images.githubusercontent.com/77303486/222219260-90d4ccef-3019-4b7f-8980-d7740a7bf5ba.png">

<img width="701" alt="Screenshot 2023-03-01 at 9 43 31 AM" src="https://user-images.githubusercontent.com/77303486/222219812-94620563-cba3-4052-b4c6-3d51020181ec.png">

