### PR TITLE
hotfix/camunda-ssl-issue-fix

### DIFF
--- a/forms-flow-bpm/src/main/resources/application.yaml
+++ b/forms-flow-bpm/src/main/resources/application.yaml
@@ -8,12 +8,12 @@ keycloak.clientSecret: ${KEYCLOAK_CLIENTSECRET}
 
 server:
   port: 8080
-  ssl:
-    key-store: classpath:/keystore.ks
-    key-store-password: BCG0vernm3nt++
-    key-store-type: pkcs12
-    key-alias: camunda
-    key-password: BCG0vernm3nt++
+  # ssl:
+  #   key-store: classpath:/keystore.ks
+  #   key-store-password: BCG0vernm3nt++
+  #   key-store-type: pkcs12
+  #   key-alias: camunda
+  #   key-password: BCG0vernm3nt++
   servlet:
     context-path: /camunda
     session:


### PR DESCRIPTION
## Summary

This PR is removing the Camunda SSL to make it run again.