### PR TITLE
DGJ-964 an API to add user in Keycloak and assign group

### DIFF
--- a/docs/AddUserAndAssignGroup/index.md
+++ b/docs/AddUserAndAssignGroup/index.md
@@ -1,0 +1,71 @@
+# Assign user to specific group on `Keycloak`
+
+It will give a context to how a `developer` can assign a group to provided users on Keycloak in bulk.
+- If the provided user exists, it will assign a group.
+- If the user does not exist, The user will be created on Keycloak and assigned to a group.
+
+> Only support's identity provider. And it is restricted to IDIR users only.
+
+> For any additional requirements, we can update the logic for the `username` and extend it to other IDP or Non-IDP users.
+
+For easy access, we have added an API. A developer can POST data on a given API. In the future, it can be integrated with Frontend as well.
+
+## Available API endpoints
+
+**Endpoint** : POST /release-note  
+**Header** : { "Authorization": "Bearer < *FORM DESIGNER TOKEN* >" }  
+**Body**: A json object.
+- group: Group name to which we want to assign users.
+- users: <user's array>
+    - firstName: <user's first name>
+    - lastName: <user's last name>
+    - email: <user's email>
+    - idp: <user's Identity provider>
+    (It only supports IDIR for now)
+
+Example,
+
+**Request body**
+```
+{
+    "group": "sl-review-****",
+    "users": [
+        {
+            "firstName": "John",
+            "lastName": "Carter",
+            "email": "John.john@gov.bc.ca",
+            "idp": "idir"
+        },
+        ...
+    ]
+}
+```
+**Response body**
+
+(You can see 2 users, one with success and one with error message)
+```
+[
+    {
+        "firstName": "Bhumin",
+        "lastName": "Maze",
+        "email": "bhumin.bhumin@gov.bc.ca",
+        "idp": "idir",
+        "user_id": "fa******-****-****-9b48-********987a",
+        "status": true,
+        "user_group": "Updated - users/fa******-****-****-9b48-********987a/groups/ae******-****-****-a674-********684f",
+        "message": "success",
+        "username": "bhumin.bhumin@gov.bc.ca_idir",
+        "enabled": true
+    },
+    {
+        "firstName": "Bhumin",
+        "lastName": "Maze",
+        "email": "bhumin.bhumin@gov.bc.ca",
+        "idp": "bcsc",
+        "user_id": null,
+        "status": false,
+        "user_group": null,
+        "message": "Supported IDPs are ('idir',)"
+    },
+]
+```

--- a/forms-flow-api/src/formsflow_api/resources/employeeData.py
+++ b/forms-flow-api/src/formsflow_api/resources/employeeData.py
@@ -88,10 +88,9 @@ class EmployeeGroup(Resource):
             group = data.get("group")
             users = data.get("users")
             if group and users:
-                obj = KeycloakService()
-                result, groupId = obj.add_users(group, users)
+                kcService = KeycloakService()
+                result, groupId = kcService.add_users(group, users)
                 if groupId:
-                    # print(er)
                     return result, HTTPStatus.OK
                 return {"errorMessage": "Group not found"}, HTTPStatus.NOT_FOUND
             else:

--- a/forms-flow-api/src/formsflow_api/schemas/__init__.py
+++ b/forms-flow-api/src/formsflow_api/schemas/__init__.py
@@ -23,3 +23,8 @@ from formsflow_api.schemas.user import UserlocaleReqSchema
 
 from .process import ProcessListSchema
 from formsflow_api.schemas.release_note import ReleaseNoteSchema
+from .keycloak_admin import (
+    KeycloakResponseSchema, 
+    KeycloakUserSchema, 
+    RequestUserSchema
+)

--- a/forms-flow-api/src/formsflow_api/schemas/keycloak_admin.py
+++ b/forms-flow-api/src/formsflow_api/schemas/keycloak_admin.py
@@ -1,0 +1,47 @@
+"""This manages keycloak services Schema."""
+
+from marshmallow import EXCLUDE, Schema, fields
+
+
+
+class KeycloakResponseSchema(Schema):
+    """This class manages aggregated response schema."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE
+
+    user_id = fields.Str(load_default=None)
+    status = fields.Boolean(load_default=False)
+    message = fields.Str(load_default=None)
+    user_group = fields.Str(load_default=None)
+
+
+class KeycloakUserSchema(Schema):
+    """This class manages aggregated keycloak user schema."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE
+
+    firstName = fields.Str(required=True)
+    lastName = fields.Str(required=True)
+    email = fields.Str(required=True)
+    username = fields.Str(required=True)
+    enabled = fields.Boolean(required=True)
+
+
+class RequestUserSchema(Schema):
+    """This class manages aggregated user request schema."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE
+
+    firstName = fields.Str(required=True)
+    lastName = fields.Str(required=True)
+    email = fields.Str(required=True)
+    idp = fields.Str(required=True)

--- a/forms-flow-api/src/formsflow_api/services/__init__.py
+++ b/forms-flow-api/src/formsflow_api/services/__init__.py
@@ -13,6 +13,7 @@ from formsflow_api.services.process import ProcessService
 from formsflow_api.services.ministry_names_service import MinistryNamesService
 from formsflow_api.services.employeeDataService import EmployeeDataService
 from formsflow_api.services.release_note import ReleaseNoteService
+from formsflow_api.services.keycloak_service import KeycloakService
 
 __all__ = [
     "ApplicationService",
@@ -27,4 +28,5 @@ __all__ = [
     "EmployeeDataService",
     "MinistryNamesService",
     "ReleaseNoteService",
+    "KeycloakService"
 ]

--- a/forms-flow-api/src/formsflow_api/services/external/keycloak.py
+++ b/forms-flow-api/src/formsflow_api/services/external/keycloak.py
@@ -166,3 +166,26 @@ class KeycloakAdminAPIService:
             raise f"Request to Keycloak Admin APIs failed., {err_code}"
         if response.status_code == 204:
             return f"Updated - {url_path}"
+
+    @profiletime
+    def create_request(  # pylint: disable=inconsistent-return-statements
+        self, url_path, data=None
+    ):
+        """Method to add POST request of Keycloak Admin APIs.
+
+        : url_path: The relative path of the API
+        : data: The request data object
+        """
+        url = f"{self.base_url}/{url_path}"
+        try:
+            response = self.session.request(
+                "POST",
+                url,
+                data=json.dumps(data),
+            )
+            current_app.logger.debug(f"keycloak Admin API POST request URL: {url}")
+            current_app.logger.debug(f"Keycloak Admin POST API payload {data}")
+            current_app.logger.debug(f"Keycloak response: {response}")
+            return response.status_code, response
+        except Exception as err_code:
+            raise f"Request to Keycloak Admin APIs failed., {err_code}"

--- a/forms-flow-api/src/formsflow_api/services/factory/keycloak_group_service.py
+++ b/forms-flow-api/src/formsflow_api/services/factory/keycloak_group_service.py
@@ -26,3 +26,25 @@ class KeycloakGroupService(KeycloakAdmin):
         return self.client.update_request(
             url_path=f"groups/{group_id}", data=dashboard_id_details
         )
+
+    def get_group_by_name(self, name: str):
+        """Get group by group name."""
+        return self.client.get_request(url_path=f"group-by-path/{name}")
+    
+    def get_user_by_username(self, username: str):
+        """Get user by username"""
+        return self.client.get_request(url_path=f"users?exact=true&username={username}")
+    
+    def create_user(self, user: Dict):
+        """Add new user"""
+        return self.client.create_request(
+            url_path=f"users", data=user
+        )
+
+    def add_user_to_group(self, user_id: str, group_id):
+        """Add user to group"""
+        return self.client.update_request(url_path=f"users/{user_id}/groups/{group_id}")
+    
+    def get_users_group(self, user_id: str):
+        """Fetch user's existing groups"""
+        return self.client.get_request(url_path=f"users/{user_id}/groups")

--- a/forms-flow-api/src/formsflow_api/services/keycloak_service.py
+++ b/forms-flow-api/src/formsflow_api/services/keycloak_service.py
@@ -7,6 +7,7 @@ from formsflow_api.schemas import (
     KeycloakResponseSchema, KeycloakUserSchema,
     RequestUserSchema
 )
+supportedIdps = ["idir"]
 
 class KeycloakService:  # pylint: disable=too-few-public-methods
     """This class manages keycloak service."""
@@ -42,9 +43,12 @@ class KeycloakService:  # pylint: disable=too-few-public-methods
             fields = ",".join(e.messages.keys())
             result["message"] = f"{fields} fields required with valid data"
             return result
+        idp = userData.get("idp")
+        if idp is None or idp not in supportedIdps:
+            result["message"] = f"Supported IDPs are {*supportedIdps,}"
+            return result
 
         username = userData.get("email")
-        idp = userData.get("idp")
         if idp and idp !="":
             username = f"{username}_{idp}"
         userData["username"] = username
@@ -58,13 +62,13 @@ class KeycloakService:  # pylint: disable=too-few-public-methods
             if status == 201:
                 userId = self.get_user_id(username)
                 result["message"] = "success"
-                result["status"] = "true"
+                result["status"] = True
             else:
                 result["message"] = f"Failed to create user with status: {status}"
         else:
             current_app.logger.debug(f"get user {userId}")
             result["message"] = "success"
-            result["status"] = "true"
+            result["status"] = True
 
         result["user_id"] = userId
         result.update(userData)

--- a/forms-flow-api/src/formsflow_api/services/keycloak_service.py
+++ b/forms-flow-api/src/formsflow_api/services/keycloak_service.py
@@ -1,0 +1,97 @@
+"""Keycloak connect and operations services for import data."""
+from http import HTTPStatus
+from marshmallow.exceptions import ValidationError
+from flask import current_app
+from formsflow_api.services.factory import KeycloakFactory
+from formsflow_api.schemas import (
+    KeycloakResponseSchema, KeycloakUserSchema,
+    RequestUserSchema
+)
+
+class KeycloakService:  # pylint: disable=too-few-public-methods
+    """This class manages keycloak service."""
+
+    def __init__(self):
+        """Initialize client."""
+        self.client = KeycloakFactory.get_instance()
+    
+    def get_group_id(self, name):
+        """fetch user from group name"""
+        try:
+            group = self.client.get_group_by_name(name)
+            return group.get('id')
+        except:
+            return None
+    
+    def get_user_id(self, username):
+        """fetch user from username, exact match"""
+        users = self.client.get_user_by_username(
+            username = username
+        )
+        userId = None
+        if len(users) > 0:
+            userId = users[0]["id"]
+        return userId
+
+    def get_user_or_add(self, userData):
+        """get user and if not exist and add new one"""
+        result = KeycloakResponseSchema().load({})
+        try:
+            userData = RequestUserSchema().load(userData)
+        except ValidationError as e:
+            fields = ",".join(e.messages.keys())
+            result["message"] = f"{fields} fields required with valid data"
+            return result
+
+        username = userData.get("email")
+        idp = userData.get("idp")
+        if idp and idp !="":
+            username = f"{username}_{idp}"
+        userData["username"] = username
+        userData["enabled"] = True
+        userId = self.get_user_id(username)
+        if not userId:
+            status, res = self.client.create_user(
+                user = KeycloakUserSchema().load(userData)
+            )
+            current_app.logger.debug("add user, status: {status}")
+            if status == 201:
+                userId = self.get_user_id(username)
+                result["message"] = "success"
+                result["status"] = "true"
+            else:
+                result["message"] = f"Failed to create user with status: {status}"
+        else:
+            current_app.logger.debug(f"get user {userId}")
+            result["message"] = "success"
+            result["status"] = "true"
+
+        result["user_id"] = userId
+        result.update(userData)
+        return result
+
+    def add_user_group(self, groupId, userData):
+        """Add user and assign group"""
+        result = self.get_user_or_add(userData)
+        if result["user_id"]:
+            try:
+                userGroup = self.client.add_user_to_group(
+                    user_id = result["user_id"],
+                    group_id = groupId
+                )
+                result["user_group"] = userGroup
+            except Exception as e:
+                result["user_group"] = str(e)
+        return result
+
+    def add_users(self, group, data):
+        """Process all users data."""
+        results = []
+        # fetch group and return faild if not found
+        groupId = self.get_group_id(group)
+        if groupId:
+            for user in data:
+                result = self.add_user_group(groupId, user)
+                user.update(result)
+                results.append(user)
+        return results, groupId


### PR DESCRIPTION
## Summary
- Added an API to automation add new users and assign provided group. 
- If user is already exist with same email/idp then only assign group.

## Changes
- Added webapi that accept user(first & last name, email and idp) object as array and group name.
- API will return same user object response with additional details like "user_id", "success" and "updated" with group to help issuer(developer or designer user) save response or display(If we integrate it with frontend).
- Only "Form Designer" are able to call this API.


## Notes
I'll add documentation and sample data for the API. As it will be handle by developer only(unless we add frontend for the same)
It will help to trigger the API from local script with designer token or from postman app. It will not required developer to collect keycloak configuration as those are already there in the WEBAPI.