### PR TITLE
Enable default user data in draft edit with 2 conditions

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -8,6 +8,7 @@
 4. [Form Access](#form-access)
 5. [Reusable Popup](#reusable-popup)
 6. [Form Retention](#form-retention)
+7. [Fetch default values in Draft](#fetch-default-values-in-draft)
 
 ## Calculated Form Values
 
@@ -157,3 +158,9 @@ The popup will be displayed like the image below:
 - `SL Review`
   - Incomplete: After initial SL submission
   - Complete: Once the SL submission has been updated and meets the end criteria (which will be discussed and updated here)
+
+## Fetch default values in Draft
+In the new form submission, we fetched logged-in users' data and pre-fill in the form.  If we want to fetch the same in the draft edit form, the below settings are required.
+
+1. Make the field `disabled` for which we want to fetch the latest data from the user object.
+2. Add the hidden field `enableDraftDefault` and set its value to `true` in the form.

--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -203,18 +203,18 @@ const View = React.memo((props) => {
    * "enableDraftDefault" is hidden param/field in the form,
    * to enable, please add it in the form and set value "true".
    */
-  if (employeeData && submission && submission.submission) {
-    if (submission.submission?.data) {
-      if (submission.submission.data?.enableDraftDefault !== undefined &&
-        submission.submission.data?.enableDraftDefault === "true") {
-        // Let's fetch default value for disbled fiedls only
-        const vals = getDefaultValues(employeeData.data, form, 'draft');
-        if (vals) {
-          submission.submission.data = {
-            ...submission.submission.data,
-            ...vals.data
-          };
-        }
+  if (employeeData && submission && submission.submission &&
+    submission.submission?.data?.enableDraftDefault) {
+      console.log("got the formfield", form);
+    if (submission.submission.data?.enableDraftDefault === "true") {
+      // Let's fetch default value for disabled fiedls only
+      console.log("got the formfield with value true");
+      const vals = getDefaultValues(employeeData.data, form, 'draft');
+      if (vals) {
+        submission.submission.data = {
+          ...submission.submission.data,
+          ...vals.data
+        };
       }
     }
   }

--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -205,10 +205,8 @@ const View = React.memo((props) => {
    */
   if (employeeData && submission && submission.submission &&
     submission.submission?.data?.enableDraftDefault) {
-      console.log("got the formfield", form);
     if (submission.submission.data?.enableDraftDefault === "true") {
       // Let's fetch default value for disabled fiedls only
-      console.log("got the formfield with value true");
       const vals = getDefaultValues(employeeData.data, form, 'draft');
       if (vals) {
         submission.submission.data = {

--- a/forms-flow-web/src/components/Draft/EditDraft.js
+++ b/forms-flow-web/src/components/Draft/EditDraft.js
@@ -7,6 +7,7 @@ import { getForm, getSubmission } from "react-formio";
 // import { Translation } from "react-i18next";
 import { MULTITENANCY_ENABLED } from "../../constants/constants";
 import { getDraftById } from "../../apiManager/services/draftService";
+import { fetchEmployeeData } from "../../apiManager/services/employeeDataService";
 import Edit from "./Edit";
 import { push } from "connected-react-router";
 
@@ -22,6 +23,7 @@ const EditDraft = React.memo(() => {
   const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : "/";
 
   useEffect(() => {
+    dispatch(fetchEmployeeData());
     dispatch(
       getDraftById(draftId, (err, res) => {
         if (!err) {


### PR DESCRIPTION
## Summary
Retrive User's latest details in Draft form, if Form has enable that option.

## Changes
- Retrive user's details if they reload draft edit page.
- Replace latest value from user's object if form fields are disabled and form has hidden field "enableDraftDefault" with value 

## Notes
Added document on how to enable this requirements.