### PR TITLE
fix/DGJ_558-delete-incomplete-submission

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/DeleteSubmissionListener.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/DeleteSubmissionListener.java
@@ -52,6 +52,8 @@ public class DeleteSubmissionListener extends BaseListener implements JavaDelega
         if (response.getStatusCode().value() == HttpStatus.OK.value()) {
             System.out.println("Application was deleted successfully: " + applicationUrl);
             JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        } else if (response.getStatusCode().value() == HttpStatus.BAD_REQUEST.value()) {
+            System.out.println("Application was not found for deletion! " +  applicationUrl);
         } else {
             throw new ApplicationServiceException("Unable to delete application for: " + applicationUrl + ". Message Body: " +
                     response.getBody());

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/services/FormSubmissionService.java
@@ -91,6 +91,8 @@ public class FormSubmissionService {
         if (response.getStatusCode().value() == HttpStatus.OK.value()) {
             System.out.println("Submission was deleted successfully: " +  submissionUrl);
             JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        } else if (response.getStatusCode().value() == HttpStatus.NOT_FOUND.value()) {
+            System.out.println("Submission was not found for deletion! " +  submissionUrl);
         } else {
             throw new FormioServiceException("Unable to delete submission for: " + submissionUrl + ". Message Body: " +
                     response.getBody());


### PR DESCRIPTION
## Summary

This pull request enhances the submission/application deletion listener in Camunda by enabling it to handle situations where the relevant data cannot be located. For instance, if a submission has already been deleted due to any reason, the delete listener will not trigger an error in Camunda. Instead, it will proceed with deleting the application and advancing the workflow seamlessly.