### PR TITLE
hotfix/add-curl-to-webapi-docker

### DIFF
--- a/forms-flow-api/Dockerfile.prod
+++ b/forms-flow-api/Dockerfile.prod
@@ -4,7 +4,7 @@ WORKDIR /forms-flow-api/app
 
 # install curl, gnupg2 and unzip
 RUN  apt-get update \
-  && apt-get install -y git
+  && apt-get install -y git curl
 
 COPY requirements.txt .
 ENV PATH=/venv/bin:$PATH


### PR DESCRIPTION
## Summary

There is an access issue with connecting to ODS endpoints locally. As a workaround, this PR adds `curl` to webApi docker image. This will allow us to ssh into that docker container and test ODS endpoints.