### PR TITLE
DGJ_906-improve-edit-page-validation

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -36,7 +36,6 @@ import { toast } from "react-toastify";
 import { Translation, useTranslation } from "react-i18next";
 import { updateCustomSubmission } from "../../../../../apiManager/services/FormServices";
 
-import _ from "lodash";
 import {
   convertFormLinksToOpenInNewTabs,
   scrollToErrorOnValidation,
@@ -75,6 +74,7 @@ const Edit = React.memo((props) => {
     user,
     showPrintButton,
     authToken,
+    editSubmissionPage,
   } = props;
 
   const formRef = useRef(null);
@@ -101,7 +101,7 @@ const Edit = React.memo((props) => {
       if (
         getUserRolePermission(userRoles, CLIENT) &&
         !CLIENT_EDIT_STATUS.includes(applicationStatus)
-      ) {
+        ) {
         dispatch(push(`/form/${formId}/submission/${submissionId}`));
       }
     }
@@ -178,21 +178,16 @@ const Edit = React.memo((props) => {
     useSelector((state) => state?.bpmTasks?.bpmTasks) &&
     useSelector((state) => state.bpmTasks.bpmTasks)[0];
 
-  // Pass along the current task with the given submission
-  // so it can be used for validation purposes.
-  const submissionWithTask = _.merge(
-    {},
-    {
-      data: {
-        task: {
-          assignedToMe:
-            task?.assignee && user?.preferred_username === task?.assignee,
-          ...(task || {}),
-        },
-      },
-    },
-    updatedSubmission
-  );
+  /* Pass along the current task and the page where this 
+  * component is opened in (e.g., edit submission page, review submission page), 
+  * so it can be used for validation purposes. 
+  * */
+  updatedSubmission.editSubmissionPage = editSubmissionPage;
+  updatedSubmission.task = {
+            assignedToMe:
+              task?.assignee && user?.preferred_username === task?.assignee,
+            ...(task || {}),
+          };
 
   if (isFormActive || (isSubActive && !isFormSubmissionLoading)) {
     return <Loading />;
@@ -284,8 +279,7 @@ const Edit = React.memo((props) => {
         <div className="ml-4 mr-4" id="formview">
           <Form
             form={form}
-            // submission={updatedSubmission}
-            submission={submissionWithTask}
+            submission={updatedSubmission}
             url={url}
             hideComponents={hideComponents}
             onSubmit={(submission) =>

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/index.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/index.js
@@ -14,6 +14,7 @@ import {
   CUSTOM_SUBMISSION_URL,
   CUSTOM_SUBMISSION_ENABLE,
   STAFF_REVIEWER,
+  EDIT_SUBMISSION_PAGE,
 } from "../../../../../constants/constants";
 import { CLIENT_EDIT_STATUS } from "../../../../../constants/applicationConstants";
 import Loading from "../../../../../containers/Loading";
@@ -115,7 +116,11 @@ const Item = React.memo(() => {
         {editAllowed ? (
           <Route
             path={`${BASE_ROUTE}form/:formId/submission/:submissionId/edit`}
-            component={Edit}
+            render={(props) => 
+              <Edit {...props} 
+                editSubmissionPage={EDIT_SUBMISSION_PAGE.isEditSubmission} 
+              />
+            }
           />
         ) : null}
         <Route

--- a/forms-flow-web/src/constants/constants.js
+++ b/forms-flow-web/src/constants/constants.js
@@ -212,3 +212,8 @@ export const DRAFT_ENABLED =
 export const SL_REVIEW_PROCESS_NAME =
   (window._env_ && window._env_.REACT_APP_SL_REVIEW_PROCESS_NAME) ||
   process.env.REACT_APP_SL_REVIEW_PROCESS_NAME;
+
+export const EDIT_SUBMISSION_PAGE = {
+  isReviewSubmission: "isReviewSubmission",
+  isEditSubmission: "isEditSubmission",
+};


### PR DESCRIPTION
## Summary

This PR fixes the issue of formio wasn't reliably know whether the submission is opened on the Edit Submission page or Review Submission page. This was required to display some form components depending on where that page is loaded.

## Changes
- A new status `editSubmissionPage` with two values was added to the form submission object.
- `ServiceFlowTaskDetails` was improved to only load the edit submission component of submission data is loaded.