### PR TITLE
feature/DGJ_1025-delete-cold-flu-registration-logic

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/influenzaWorksite.py
+++ b/forms-flow-api/src/formsflow_api/resources/influenzaWorksite.py
@@ -124,3 +124,20 @@ class InfluenzaWorksite(Resource):
         except BusinessException as err:
             current_app.logger.warning(err.error)
             return err.error, err.status_code
+
+@cors_preflight("DELETE, OPTIONS")
+@API.route("/worksites_registrations/<int:application_id>", methods=["DELETE", "OPTIONS"])
+class InfluenzaWorksiteById(Resource):
+    """Resource for worksites_registrations by id"""
+
+    @staticmethod
+    @profiletime
+    @auth.require
+    def delete(application_id: int):
+        """delete influenza worksites_registrations by application_id"""
+        try:
+            InfluenzaService.delete_worksites_registrations(application_id)
+            return "Deleted", HTTPStatus.OK
+        except BusinessException as err:
+            current_app.logger.warning(err.error)
+            return err.error, err.status_code

--- a/forms-flow-api/src/formsflow_api/resources/influenzaWorksite.py
+++ b/forms-flow-api/src/formsflow_api/resources/influenzaWorksite.py
@@ -133,6 +133,7 @@ class InfluenzaWorksiteById(Resource):
     @staticmethod
     @profiletime
     @auth.require
+    @auth.has_one_of_roles(["formsflow-designer"])
     def delete(application_id: int):
         """delete influenza worksites_registrations by application_id"""
         try:

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -507,7 +507,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
         application = Application.find_by_id(application_id=application_id)
         if application:
             application.delete()
-            current_app.logger.info(f"application was deleted by id {application_id}")
+            current_app.logger.info(f"application was deleted in webApi DB by id {application_id}")
         else:
             raise BusinessException(f"Invalid application by id:{application_id}", HTTPStatus.BAD_REQUEST)
     
@@ -517,6 +517,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
         formio_service = FormioService()
         form_io_token = formio_service.get_formio_access_token()
         formio_service.delete_submission(form_io_token, application.latest_form_id, application.submission_id)
+        current_app.logger.info(f"application was deleted in formio DB by submission id {application.submission_id}")
 
     @staticmethod
     def delete_application_from_ODS(application_id: int):

--- a/forms-flow-api/src/formsflow_api/services/influenza_service.py
+++ b/forms-flow-api/src/formsflow_api/services/influenza_service.py
@@ -183,7 +183,8 @@ class InfluenzaService:
            headers={"Authorization": auth_token},
            json={"application_id": application_id}
           )
+        current_app.logger.info(f"application was deleted in ODS (warehouse) by id {application_id}")
       except:
         raise BusinessException(
-          {"message": "Failed to delete worksites_registration in ODS with application_id: " + str(application_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
+          {"message": f"Failed to delete worksites_registration in ODS (warehouse) with application_id: {application_id}"}, HTTPStatus.INTERNAL_SERVER_ERROR
         )

--- a/forms-flow-api/src/formsflow_api/services/influenza_service.py
+++ b/forms-flow-api/src/formsflow_api/services/influenza_service.py
@@ -172,3 +172,18 @@ class InfluenzaService:
         raise BusinessException(
           {"message": "No worksites_registrations found"}, HTTPStatus.NOT_FOUND
         )
+    
+    @staticmethod
+    def delete_worksites_registrations(application_id):
+      delete_worksites_registrations_url = current_app.config.get("ODS_URL") + "/ods_datamart_influenza_delete_registration"
+      auth_token = current_app.config.get("ODS_AUTH_TOKEN")
+      try:
+        requests.post(
+           delete_worksites_registrations_url, 
+           headers={"Authorization": auth_token},
+           json={"application_id": application_id}
+          )
+      except:
+        raise BusinessException(
+          {"message": "Failed to delete worksites_registration in ODS with application_id: " + str(application_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
+        )


### PR DESCRIPTION
## Summary

This PR allows users to delete the submitted applications -- a requirement for Cold/flu submissions. This is the logic part of #1025 ticket

## Changes

- Added an endpoint to delete submissions from the ODS warehouse
- Added/updated delete application from webApi/formio DBs from an endpoint which was added a while ago but left with no use ♻️

## Notes

At this point, regular users can only delete their own applications and a designer can delete their own and others. That part of the logic will be updated when a new group/role for cold/flu admin is added to handle that special condition.