### PR TITLE
feature/DGJ_1075-cold-flu-admin

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
@@ -18,7 +18,8 @@ from .constants import (
     KEYCLOAK_DASHBOARD_BASE_GROUP,
     NEW_APPLICATION_STATUS,
     REVIEWER_GROUP,
-    HTTP_TIMEOUT
+    HTTP_TIMEOUT,
+    COLD_FLU_ADMIN_GROUP,
 )
 from .enums import ApplicationSortingParameters
 from .format import CustomFormatter

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
@@ -14,6 +14,7 @@ if FORMSFLOW_API_CORS_ORIGINS != "*":
 DESIGNER_GROUP = "formsflow-designer"
 REVIEWER_GROUP = "formsflow-reviewer"
 CLIENT_GROUP = "formsflow-client"
+COLD_FLU_ADMIN_GROUP = "cold-flu-admin"
 FORMSFLOW_ROLES = [DESIGNER_GROUP, REVIEWER_GROUP, CLIENT_GROUP]
 ALLOW_ALL_APPLICATIONS = "/formsflow/formsflow-reviewer/access-allow-applications"
 

--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -312,12 +312,20 @@ class Application(
         order_by: str,
         sort_order: str,
         process_key: str,
+        user_id: str = None,
         **filters,
     ):
-        """Fetch applications list based on searching parameters for Reviewer."""
+        """Fetch applications list based on searching parameters for Reviewer/admin roles."""
         query = cls.filter_conditions(**filters)
         query = FormProcessMapper.tenant_authorization(query=query)
-        query = query.filter(FormProcessMapper.process_key.in_(process_key))
+        if user_id:
+            # get all applications created by user plus applications for the process_keys
+            query = query.filter(or_(
+                FormProcessMapper.process_key.in_(process_key), 
+                Application.created_by == user_id))
+        else:
+            # get all applications for the process_keys
+            query = query.filter(FormProcessMapper.process_key.in_(process_key))
         query = cls.filter_draft_applications(query=query)
         order_by, sort_order = validate_sort_order_and_order_by(order_by, sort_order)
         if order_by and sort_order:

--- a/forms-flow-api/src/formsflow_api/resources/application.py
+++ b/forms-flow-api/src/formsflow_api/resources/application.py
@@ -11,6 +11,7 @@ from formsflow_api_utils.utils import (
     cors_preflight,
     get_form_and_submission_id_from_form_url,
     profiletime,
+    COLD_FLU_ADMIN_GROUP,
 )
 from marshmallow.exceptions import ValidationError
 
@@ -82,6 +83,30 @@ class ApplicationsResource(Resource):
                     token=request.headers["Authorization"],
                     page_no=page_no,
                     limit=limit,
+                )
+            elif auth.has_role([COLD_FLU_ADMIN_GROUP]):
+                influenza_worksite_process_key = current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY")
+                if influenza_worksite_process_key is None:
+                    current_app.logger.warning("INFLUENZA_WORKSITE_PROCESS_KEY is not set")
+                (
+                    application_schema_dump,
+                    application_count,
+                    draft_count,
+                ) = ApplicationService.get_all_applications_by_user_by_process_keys_and_count(
+                    created_from=created_from_date,
+                    created_to=created_to_date,
+                    modified_from=modified_from_date,
+                    modified_to=modified_to_date,
+                    order_by=order_by,
+                    sort_order=sort_order,
+                    created_by=created_by,
+                    application_id=application_id,
+                    application_name=application_name,
+                    application_status=application_status,
+                    token=request.headers["Authorization"],
+                    page_no=page_no,
+                    limit=limit,
+                    process_keys=[influenza_worksite_process_key],
                 )
             else:
                 (

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -213,6 +213,55 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
             get_all_applications_count,
             draft_count,
         )
+    
+    @staticmethod
+    @user_context
+    def get_all_applications_by_user_by_process_keys_and_count(  # pylint: disable=too-many-arguments,too-many-locals
+        page_no: int,
+        limit: int,
+        order_by: str,
+        created_from: datetime,
+        created_to: datetime,
+        modified_from: datetime,
+        modified_to: datetime,
+        application_id: int,
+        application_name: str,
+        application_status: str,
+        created_by: str,
+        sort_order: str,
+        token: str,
+        process_keys: list,
+        **kwargs
+    ):
+        """Get applications by user by process keys."""
+        user: UserContext = kwargs["user"]
+        user_id: str = user.user_name
+        
+        (
+            applications,
+            get_all_applications_count,
+        ) = Application.find_applications_by_process_key(
+            application_id=application_id,
+            application_name=application_name,
+            application_status=application_status,
+            created_by=created_by,
+            page_no=page_no,
+            limit=limit,
+            order_by=order_by,
+            modified_from=modified_from,
+            modified_to=modified_to,
+            sort_order=sort_order,
+            created_from=created_from,
+            created_to=created_to,
+            process_key=process_keys,
+            user_id=user_id,
+        )
+        draft_count = Draft.get_draft_count()
+        return (
+            application_schema.dump(applications, many=True),
+            get_all_applications_count,
+            draft_count,
+        )
 
     @staticmethod
     @user_context

--- a/forms-flow-web/src/constants/constants.js
+++ b/forms-flow-web/src/constants/constants.js
@@ -65,6 +65,7 @@ export const STAFF_REVIEWER = "formsflow-reviewer";
 export const ANONYMOUS_USER = "anonymous";
 
 export const MANAGER_GROUP = 'manager';
+export const COLD_FLU_ADMIN_GROUP = 'cold-flu-admin';
 
 export const FORMIO_JWT_SECRET =
   (window._env_ && window._env_.REACT_APP_FORMIO_JWT_SECRET) || process.env.REACT_APP_FORMIO_JWT_SECRET || "--- change me now ---";


### PR DESCRIPTION
## Summary

This PR adds the `cold-flu-admin` group/admin to the platform and will allow them to view all the cold-flu related submitted applications plus their own submissions. Ticket #1075

## Changes

- `cold-flu-admin` group and the associated role was added to Keycloak
- webApi endpoint was updated to allow the `cold-flu-admin` role to view all the related applications plus own

