### PR TITLE
feature/DGJ_1082-allow-cold-flu-admin-access-cold-flu-submissions

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
@@ -36,6 +36,7 @@ class FormioRoles(Enum):
     DESIGNER = "administrator"
     ANONYMOUS = "anonymous"
     RESOURCE_ID = "RESOURCE_ID"
+    COLD_FLU_ADMIN = "cold-flu-admin"
 
     @classmethod
     def contains(cls, item: str) -> bool:

--- a/forms-flow-api/src/formsflow_api/resources/application.py
+++ b/forms-flow-api/src/formsflow_api/resources/application.py
@@ -192,6 +192,15 @@ class ApplicationResourceById(Resource):
                     application_schema_dump,
                     status,
                 )
+            if auth.has_role([COLD_FLU_ADMIN_GROUP]):
+                influenza_worksite_process_key = current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY")
+                if influenza_worksite_process_key is None:
+                    current_app.logger.warning("INFLUENZA_WORKSITE_PROCESS_KEY is not set")
+                application, status = ApplicationService.get_application_by_user(
+                    application_id=application_id, process_keys=[influenza_worksite_process_key]
+                )
+                return (application, status)
+            
             application, status = ApplicationService.get_application_by_user(
                 application_id=application_id
             )

--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -11,6 +11,7 @@ from formsflow_api_utils.utils import (
     CLIENT_GROUP,
     DESIGNER_GROUP,
     REVIEWER_GROUP,
+    COLD_FLU_ADMIN_GROUP,
     auth,
     cache,
     cors_preflight,
@@ -41,7 +42,6 @@ class FormioResource(Resource):
         """Get role ids from cache."""
         user: UserContext = kwargs["user"]
         assert user.token_info is not None
-
         def filter_user_based_role_ids(item):
             filter_list = []
             if DESIGNER_GROUP in user.roles:
@@ -50,8 +50,9 @@ class FormioResource(Resource):
                 filter_list.append(FormioRoles.REVIEWER.name)
             if CLIENT_GROUP in user.roles:
                 filter_list.append(FormioRoles.CLIENT.name)
+            if COLD_FLU_ADMIN_GROUP in user.roles:
+                filter_list.append(FormioRoles.COLD_FLU_ADMIN.name)
             return item["type"] in filter_list
-
         @after_this_request
         def add_jwt_token_as_header(response):
             _role_ids = [

--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -42,6 +42,7 @@ class FormioResource(Resource):
         """Get role ids from cache."""
         user: UserContext = kwargs["user"]
         assert user.token_info is not None
+
         def filter_user_based_role_ids(item):
             filter_list = []
             if DESIGNER_GROUP in user.roles:
@@ -53,6 +54,7 @@ class FormioResource(Resource):
             if COLD_FLU_ADMIN_GROUP in user.roles:
                 filter_list.append(FormioRoles.COLD_FLU_ADMIN.name)
             return item["type"] in filter_list
+
         @after_this_request
         def add_jwt_token_as_header(response):
             _role_ids = [

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -386,12 +386,12 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     @user_context
-    def get_application_by_user(application_id: int, **kwargs):
+    def get_application_by_user(application_id: int, process_keys: list = None, **kwargs):
         """Get application by user id."""
         user: UserContext = kwargs["user"]
         user_id: str = user.user_name
         application = Application.find_id_by_user(
-            application_id=application_id, user_id=user_id
+            application_id=application_id, user_id=user_id, process_keys=process_keys
         )
         if application:
             return ApplicationSchema().dump(application), HTTPStatus.OK


### PR DESCRIPTION

## Summary

This PR adds `cold-flu-admin` to the formio JWT token to make it possible to the `cold-flu-admin` accessing submissions for that form. Also, enable access for that admin to get all cold/flu applications in webApi. Ticket #1082, #1075

## Changes

- `cold-flu-admin` role was added to formio token
- getApplicationById was updated to also support cold-flu-admin role

## Notes
At this point `cold-flu-admin` needs to be manually added to the formio MongoDB (roles table). I'll add another PR that automatically add that role on DB creation, along with the process to add a new role to fomrio and how to set it up for a form.