### PR TITLE
fix/DGJ_1082-cold-flu-admin-role-on-form-update

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -22,7 +22,7 @@ import Modal from "react-bootstrap/Modal";
 import { formio_resourceBundles } from "../../../resourceBundles/formio_resourceBundles";
 import { clearFormError } from "../../../actions/formActions";
 import { addTenankey, removeTenantKey } from "../../../helper/helper";
-import { getFormSupportedIDPFromJSON } from "../../../helper/formUtils";
+import { getFormSupportedIDPFromJSON, mergeFormioAccessRoles } from "../../../helper/formUtils";
 const reducer = (form, { type, value }) => {
   const formCopy = _cloneDeep(form);
   switch (type) {
@@ -171,7 +171,29 @@ const Edit = React.memo(() => {
   const saveFormData = () => {
     setFormSubmitted(true);
     const newFormData = addHiddenApplicationComponent(form);
-    newFormData.submissionAccess = submissionAccess;
+
+    const roleIdsFromLocalStorage = localStorage.getItem("roleIds")
+      ? JSON.parse(localStorage.getItem("roleIds"))
+      : undefined;
+    const COLD_FLU_ADMIN_ROLE_ID = roleIdsFromLocalStorage?.find(
+      (el) => el.type === "COLD_FLU_ADMIN"
+    )?.roleId;
+    const prevFormDataSubmissionAccess = _cloneDeep(formData).submissionAccess;
+    // Keep cold-flu-admin role if exists
+    if (COLD_FLU_ADMIN_ROLE_ID &&
+      prevFormDataSubmissionAccess
+        .map((el) => el.roles)
+        .flat()
+        .some((el) => el === COLD_FLU_ADMIN_ROLE_ID)
+    ) {
+      const mergedSubmissionAccess = mergeFormioAccessRoles(
+        prevFormDataSubmissionAccess,
+        submissionAccess
+      );
+      newFormData.submissionAccess = mergedSubmissionAccess;
+    } else {
+      newFormData.submissionAccess = submissionAccess;
+    }
     newFormData.access = formAccess;
     if (MULTITENANCY_ENABLED && tenantKey) {
       if (newFormData.path) {
@@ -259,7 +281,7 @@ const Edit = React.memo(() => {
     dispatchFormAction({ type: path, value });
   };
 
-  const formChange = (newForm) =>
+  const formChange = (newForm) => 
     dispatchFormAction({ type: "formChange", value: newForm });
 
   // loading up to set the data to the form variable

--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -281,7 +281,7 @@ const Edit = React.memo(() => {
     dispatchFormAction({ type: path, value });
   };
 
-  const formChange = (newForm) => 
+  const formChange = (newForm) =>
     dispatchFormAction({ type: "formChange", value: newForm });
 
   // loading up to set the data to the form variable

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -159,6 +159,32 @@ const getFormSupportedIDPFromJSON = (formio) => {
   return null;
 };
 
+function mergeFormioAccessRoles(array1, array2) {
+  const mergedArray = [];
+
+  // Helper function to merge roles by type
+  const mergeRoles = (obj, array) => {
+    const existingObj = array.find(item => item.type === obj.type);
+    if (existingObj) {
+      existingObj.roles = [...new Set([...existingObj.roles, ...obj.roles])];
+    } else {
+      array.push({ ...obj, roles: [...new Set([...obj.roles])] });
+    }
+  };
+
+  // Iterate through array1 and merge roles by type
+  array1.forEach(obj => {
+    mergeRoles(obj, mergedArray);
+  });
+
+  // Iterate through array2 and merge roles by type
+  array2.forEach(obj => {
+    mergeRoles(obj, mergedArray);
+  });
+
+  return mergedArray;
+}
+
 export {
   convertFormLinksToOpenInNewTabs,
   scrollToErrorOnValidation,
@@ -167,5 +193,6 @@ export {
   hasUserAccessToForm,
   getDefaultValues,
   getFormSupportedIDPFromJSON, 
-  setValueForComponents
+  setValueForComponents,
+  mergeFormioAccessRoles,
 };


### PR DESCRIPTION
## Summary

This PR fixes the issue of dropping `cold-flu-admin` submission access during the form update in the form builder. #1082 #1075 

## Changes

- Check to see if the `cold-flu-admin` role is part of the editing form, and keep it in that case
