### PR TITLE
feature/DGJ_1075-add-cold-flu-admin-to-formio-start-template

### DIFF
--- a/forms-flow-forms/Dockerfile
+++ b/forms-flow-forms/Dockerfile
@@ -5,7 +5,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM docker.io/node:14.18.3
+FROM node:16-buster
 
 # set working directory
 WORKDIR /forms-flow-forms/app

--- a/forms-flow-forms/formsflow-template.json
+++ b/forms-flow-forms/formsflow-template.json
@@ -33,6 +33,12 @@
       "description": "A person who can do form submission.",
       "admin": false,
       "default": false
+    },
+    "cold-flu-admin": {
+      "title": "cold-flu-admin",
+      "description": "A person who can view all cold-flu form submissions.",
+      "admin": false,
+      "default": false
     }
   },
   "forms": {


### PR DESCRIPTION
## Summary

This PR adds `cold-flu-admin` role to the Formio template to make sure that role is automatically loaded on the image build.

## Changes

- `cold-flu-admin` was added to start the template file in Formio
- Node image version was upgraded to v16 as I was getting errors building v14 on my local.

## Notes

We need to keep on eye on formio node v14 image, and possibly update it to v16 as I got an error when building v14.