### PR TITLE
update/formio-node-version-upgrade

### DIFF
--- a/forms-flow-forms/Dockerfile.prod
+++ b/forms-flow-forms/Dockerfile.prod
@@ -5,7 +5,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM docker.io/node:14.18.3
+FROM node:16-buster
 
 # set working directory
 WORKDIR /forms-flow-forms/app


### PR DESCRIPTION
## Summary

This PR upgrade Formio Prod image from Node v14 to v16. The current version, v14, has some issues installing image dependency, apparently it is no longer supported.