### PR TITLE
feature/DGJ_1158-custom-submission-loading

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -92,6 +92,8 @@ const View = React.memo((props) => {
   const [showPopup, setShowPopup] = useState(false);
   const [popupData, setPopupData] = useState();
 
+  const [isCustomFormSubmissionLoading, setIsCustomFormSubmissionLoading] = React.useState(false);
+  
   const {
     isAuthenticated,
     submission,
@@ -274,6 +276,9 @@ const View = React.memo((props) => {
           redirectPath: evt.redirectPath,
         });
         break;
+      case CUSTOM_EVENT_TYPE.CUSTOM_SUBMISSION_LOADING:
+        setIsCustomFormSubmissionLoading(true);
+        break;
       default:
         return;
     }
@@ -345,9 +350,10 @@ const View = React.memo((props) => {
       </div>
       <Errors errors={errors} />
       <LoadingOverlay
-        active={isFormSubmissionLoading}
+        active={isFormSubmissionLoading || isCustomFormSubmissionLoading}
         spinner
-        text={<Translation>{(t) => t("Loading...")}</Translation>}
+        // text={<Translation>{(t) => t("Loading...")}</Translation>}
+        text={isFormSubmissionLoading || isCustomFormSubmissionLoading ? "Submitting..." : "Loading..."}
         className="col-12"
       >
         <div className="ml-4 mr-4" id="formview">

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -79,6 +79,8 @@ const Edit = React.memo((props) => {
 
   const formRef = useRef(null);
 
+  const [isCustomFormSubmissionLoading, setIsCustomFormSubmissionLoading] = React.useState(false);
+
   const applicationStatus = useSelector(
     (state) => state.applications.applicationDetail?.applicationStatus || ""
   );
@@ -242,7 +244,10 @@ const Edit = React.memo((props) => {
         break;
       case CUSTOM_EVENT_TYPE.ERROR_CUSTOM_VALIDATION:
         toast.error(customEvent.error);
-        break;  
+        break;
+      case CUSTOM_EVENT_TYPE.CUSTOM_SUBMISSION_LOADING:
+        setIsCustomFormSubmissionLoading(true);
+        break;
       default:
         return;
     }
@@ -271,9 +276,9 @@ const Edit = React.memo((props) => {
       </div>
       <Errors errors={errors} />
       <LoadingOverlay
-        active={isFormSubmissionLoading}
+        active={isFormSubmissionLoading || isCustomFormSubmissionLoading}
         spinner
-        text={t("Loading...")}
+        text={isFormSubmissionLoading || isCustomFormSubmissionLoading ? "Submitting..." : "Loading..."}
         className="col-12"
       >
         <div className="ml-4 mr-4" id="formview">

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -123,6 +123,8 @@ const View = React.memo((props) => {
   const [showPopup, setShowPopup] = useState(false);
   const [popupData, setPopupData] = useState();
 
+  const [isCustomFormSubmissionLoading, setIsCustomFormSubmissionLoading] = React.useState(false);
+
   const {
     isAuthenticated,
     hideComponents,
@@ -463,6 +465,9 @@ const View = React.memo((props) => {
           redirectPath: evt.redirectPath,
         });
         break;
+      case CUSTOM_EVENT_TYPE.CUSTOM_SUBMISSION_LOADING:
+        setIsCustomFormSubmissionLoading(true);
+        break;
       default:
         return;
     }
@@ -552,13 +557,13 @@ const View = React.memo((props) => {
       </div>
       <Errors errors={errors} />
       <LoadingOverlay
-        active={isFormSubmissionLoading || employeeData.loading}
+        active={isFormSubmissionLoading || isCustomFormSubmissionLoading || employeeData.loading}
         spinner
         // text={<Translation>{(t) => t("Loading...")}</Translation>}
         text={
           employeeData.loading
             ? "Loading user data..."
-            : isFormSubmissionLoading
+            : isFormSubmissionLoading || isCustomFormSubmissionLoading
             ? "Submitting..."
             : "Loading..."
         }

--- a/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
+++ b/forms-flow-web/src/components/ServiceFlow/constants/customEventTypes.js
@@ -9,4 +9,5 @@ export const CUSTOM_EVENT_TYPE = {
   ERROR_CUSTOM_VALIDATION: "errorCustomValidation",
   POPUP: "popup",
   FORMACCESS: "formaccess",
+  CUSTOM_SUBMISSION_LOADING: "customSubmissionLoading",
 };


### PR DESCRIPTION
## Summary

This PR adds a loading indicator for the custom submission buttons. #1158 

## Changes

- A new event type was added for custom submission loading
- A new state to capture custom submission loading was added to new form submission, draft and edit submission pages

## Notes

Once this PR is deployed, I'll be changing all custom submission buttons to reflect the new loading feature.