### PR TITLE
DGJ_1159--sl_review_role_name_change

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
@@ -15,6 +15,7 @@ DESIGNER_GROUP = "formsflow-designer"
 REVIEWER_GROUP = "formsflow-reviewer"
 CLIENT_GROUP = "formsflow-client"
 COLD_FLU_ADMIN_GROUP = "cold-flu-admin"
+SL_REVIEW_ADMIN_GROUP = "sl-review-adm"
 FORMSFLOW_ROLES = [DESIGNER_GROUP, REVIEWER_GROUP, CLIENT_GROUP]
 ALLOW_ALL_APPLICATIONS = "/formsflow/formsflow-reviewer/access-allow-applications"
 

--- a/forms-flow-api/src/formsflow_api/resources/employeeData.py
+++ b/forms-flow-api/src/formsflow_api/resources/employeeData.py
@@ -8,6 +8,7 @@ from formsflow_api_utils.utils import (
     auth,
     cors_preflight,
     profiletime,
+    SL_REVIEW_ADMIN_GROUP,
 )
 from formsflow_api_utils.exceptions import BusinessException
 from formsflow_api.services import EmployeeDataService, KeycloakService
@@ -15,7 +16,6 @@ from formsflow_api.services import EmployeeDataService, KeycloakService
 
 
 API = Namespace("EmployeeData", description="Employee Data realted operations")
-EMPLOYEE_SEARCH_ROLE = "employee-search"
 
 @cors_preflight("GET, OPTIONS")
 @API.route("/me", methods=["GET", "OPTIONS"])
@@ -61,7 +61,7 @@ class EmployeeNames(Resource):
     @staticmethod
     @profiletime
     @auth.require
-    @auth.has_one_of_roles([EMPLOYEE_SEARCH_ROLE])
+    @auth.has_one_of_roles([SL_REVIEW_ADMIN_GROUP])
     def get():
         """Get employee names from ODS. Users must have employee-search role to be able to access this endpoint."""
 


### PR DESCRIPTION
## Summary

This PR changes `sl-review-adm` mapped role name from `employee-serach` to the same name -- making it consistent with other group-role mapping names. #1159 