### PR TITLE
feature/DGJ_1100-crm-service-create-incident

### DIFF
--- a/deployment/openshift/bpm_dc.yaml
+++ b/deployment/openshift/bpm_dc.yaml
@@ -249,6 +249,16 @@ objects:
                     configMapKeyRef:
                       name: forms-flow-ai-config
                       key: BPM_CLIENT_CONN_TIMEOUT
+                - name: CRM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: forms-flow-ai-config
+                      key: CRM_URL
+                - name: CRM_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: forms-flow-ai-config
+                      key: CRM_AUTH
 
               imagePullPolicy: Always
               livenessProbe:

--- a/deployment/openshift/camunda_dc.yaml
+++ b/deployment/openshift/camunda_dc.yaml
@@ -228,6 +228,16 @@ objects:
                     configMapKeyRef:
                       name: forms-flow-ai-config
                       key: BPM_CLIENT_CONN_TIMEOUT
+                - name: CRM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: forms-flow-ai-config
+                      key: CRM_URL
+                - name: CRM_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: forms-flow-ai-config
+                      key: CRM_AUTH
 
               imagePullPolicy: Always
               livenessProbe:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - WEB_BASE_URL=${WEB_BASE_URL}
       - ODS_URL=${ODS_URL}
       - ODS_AUTH_TOKEN=${ODS_AUTH_TOKEN}
+      - CRM_URL=${CRM_URL}
+      - CRM_AUTH_TOKEN=${CRM_AUTH_TOKEN}
       - KEYCLOAK_URL=${KEYCLOAK_URL}
       - KEYCLOAK_URL_REALM=${KEYCLOAK_URL_REALM:-forms-flow-ai}
       - KEYCLOAK_CLIENTID=${KEYCLOAK_BPM_CLIENT_ID:-forms-flow-bpm}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/HTTPServiceInvoker.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/HTTPServiceInvoker.java
@@ -51,6 +51,8 @@ public class HTTPServiceInvoker {
     private String fileServiceUrl;
     @Value("${formsflow.ai.documentApi.url}")
     private String documentApiUrl;
+    @Value("${formsflow.ai.crm.url}")
+    private String crmUrl;
 
     public ResponseEntity<String> execute(String url, HttpMethod method, Object payload) throws IOException {
         String dataJson = payload != null ? bpmObjectMapper.writeValueAsString(payload) : null;
@@ -91,6 +93,8 @@ public class HTTPServiceInvoker {
             }
         } else if (StringUtils.contains(url, odsUrl)) {
             return "ODSAccessHandler";
+        } else if (StringUtils.contains(url, crmUrl)) {
+            return "CRMAccessHandler";
         } else if (StringUtils.contains(url, fileServiceUrl)) {
             return "fileAccessHandler";
         } else if (StringUtils.contains(url, documentApiUrl)) {

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/CRMAccessHandler.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/connector/support/CRMAccessHandler.java
@@ -1,0 +1,48 @@
+package org.camunda.bpm.extension.commons.connector.support;
+
+import com.google.gson.JsonObject;
+
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
+
+
+/**
+ * This class serves as gateway for all CRM service interactions.
+ */
+@Service("CRMAccessHandler")
+public class CRMAccessHandler extends AbstractAccessHandler {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(CRMAccessHandler.class);
+
+    @Autowired
+    private WebClient unauthenticatedWebClient;
+
+    @Value("${formsflow.ai.crm.security.token}")
+    private String crmAuthHeader;
+
+    public ResponseEntity<String> exchange(String url, HttpMethod method, String payload) {
+        payload = (payload == null) ? new JsonObject().toString() : payload;
+
+        Mono<ResponseEntity<String>> entityMono = unauthenticatedWebClient.method(method).uri(url)
+                .header("Authorization", crmAuthHeader)
+                .accept(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header("osvc-crest-application-context", "Retrieve Data")
+                .body(Mono.just(payload), String.class)
+                .retrieve()
+                .toEntity(String.class);
+
+        ResponseEntity<String> response = entityMono.block();
+        return new ResponseEntity<>(response.getBody(), response.getStatusCode());
+    }
+
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -1,0 +1,251 @@
+package org.camunda.bpm.extension.hooks.listeners;
+
+import org.camunda.bpm.engine.delegate.*;
+import org.camunda.bpm.extension.commons.connector.HTTPServiceInvoker;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.camunda.bpm.extension.hooks.exceptions.ApplicationServiceException;
+import org.camunda.bpm.extension.hooks.model.Attachment;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import main.java.org.camunda.bpm.extension.hooks.model.CrmFileAttachmentPostRequest;
+import main.java.org.camunda.bpm.extension.hooks.model.CrmPostRequest;
+import main.java.org.camunda.bpm.extension.hooks.model.CrmPostResponse;
+import main.java.org.camunda.bpm.extension.hooks.model.EntryType;
+import main.java.org.camunda.bpm.extension.hooks.model.PrimaryContact;
+import main.java.org.camunda.bpm.extension.hooks.model.Thread;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+import javax.activation.DataSource;
+
+import org.slf4j.*;
+import org.camunda.bpm.extension.hooks.services.EmailAttachmentService;
+import org.camunda.bpm.extension.hooks.services.FormSubmissionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import java.io.IOException;
+
+import javax.annotation.Resource;
+
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+
+@Named("CrmDelegate")
+public class CrmDelegate extends BaseListener implements JavaDelegate {
+    private final static Logger LOGGER = LoggerFactory.getLogger(CrmDelegate.class.getName());
+    private static final String FORM_ID = "formId";
+    private static final String SUBMISSION_ID = "submissionId";
+    private static final String FORM_URL = "formUrl";
+    private static final String INCIDENTS = "incidents";
+    private static final String CONTACTS = "contacts";
+    private static final String TEST_PDF = "test.pdf";
+
+    @Autowired
+    private HTTPServiceInvoker httpServiceInvoker;
+
+    @Value("${formsflow.ai.crm.url}")
+    private String crmUrl;
+
+    @Autowired
+    private EmailAttachmentService attachmentService;
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        this.crmOperation(execution);
+    }
+
+    private void crmOperation(DelegateExecution execution) {
+        System.out.println("Starting CRM operation");
+
+        // Get the formId and submissionId from the formUrl
+        String formUrl = String.valueOf(execution.getVariables().get(FORM_URL));
+        Map<String, String> ids = extractIds(formUrl);
+        String formId = ids.get(FORM_ID);
+        String submissionId = ids.get(SUBMISSION_ID);
+        
+        if (formId == null || submissionId == null) {
+            System.out.println("formId or submissionId is null. formUrl: " + formUrl + " formId: " + formId + " submissionId" + submissionId);
+            throw new ApplicationServiceException("formId or submissionId is null");
+        }
+
+        // Find current user's idir
+        String currentUserIdir = null;
+        try {
+            currentUserIdir = getCurrentUserIdir(execution);
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println("No idir user found! Exception: " + e);
+        }
+        if (currentUserIdir == null) {
+            System.out.println("currentUserIdir is null: " + currentUserIdir);
+            throw new ApplicationServiceException("currentUserIdir is null");
+        }
+        
+        // Find the manager's contact details in CRM
+        Integer contactId = getContactId(currentUserIdir);
+        if (contactId == null) {
+            System.out.println("contactId is null: " + contactId);
+            throw new ApplicationServiceException("contactId is null");
+        }
+
+        // Create a new incident in CRM
+        CrmPostResponse crmPostResponse = createCrmIncident(contactId);
+        if (crmPostResponse == null) {
+            System.out.println("crmPostResponse is null: " + crmPostResponse);
+            throw new ApplicationServiceException("createCrmIncident failed.");
+        }
+        // Saving the CRM incident id and lookupName in form
+        execution.setVariable("crmId", crmPostResponse.getId());
+        execution.setVariable("crmLookupName", crmPostResponse.getLookupName());
+
+        // Generate a PDF of the form submission
+        try {
+            String pdfName = "test.pdf"; //Todo - change to a more meaningful name
+            generateAndAddPDFForForm(formId, submissionId, crmPostResponse.getId());
+        } catch (Exception e) {
+            System.out.println("generatePDFForForm failed. Exception: " + e);
+            e.printStackTrace();
+        }
+        
+        System.out.println("Finished CRM operation");
+    }
+
+    private CrmPostResponse createCrmIncident(int contactId) {
+        String incidentSubject = "Test incident from Camunda";
+        PrimaryContact primaryContact = new PrimaryContact(contactId);
+        EntryType entryType = new EntryType(1);
+        Thread thread1 = new Thread("thread text test 1", entryType); //Todo - later will be extracted from the form submission fields
+        ArrayList<Thread> threads = new ArrayList<Thread>();
+        threads.add(thread1);
+        CrmPostRequest crmPostRequest = new CrmPostRequest(primaryContact, incidentSubject, threads);
+        String url = getEndpointUrl(INCIDENTS);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            ResponseEntity<String> response = httpServiceInvoker.execute(
+                url, HttpMethod.POST, objectMapper.writeValueAsString(crmPostRequest));
+            String responseBody = response.getBody();
+            HttpStatus responseStatus = response.getStatusCode();
+            ObjectMapper objectMapper2 = new ObjectMapper();
+            JsonNode jsonNode = objectMapper2.readTree(response.getBody());
+            Integer incidentId = jsonNode.path("id").asInt();
+            String incidentLookupName = jsonNode.path("lookupName").asText();
+            if (incidentId == 0 || incidentLookupName.isEmpty()) {
+                System.out.println("incidentId or incidentLookupName is not found. incidentId: " + incidentId + " incidentLookupName: " + incidentLookupName);
+                return null;
+            }
+            CrmPostResponse crmPostResponse = new CrmPostResponse(incidentId, incidentLookupName);
+            return crmPostResponse;
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private Integer getContactId(String contactIdir) {
+        String idirQueryParam = "?q=login=" + "'"+ contactIdir.toLowerCase() + "'";
+        String queryParam = CONTACTS + idirQueryParam;
+        String url = getEndpointUrl(queryParam);
+        ResponseEntity<String> response = this.httpServiceInvoker.execute(url, HttpMethod.GET, null);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = objectMapper.readTree(response.getBody());
+            // Navigate to the "items" array and get the first item
+            JsonNode items = jsonNode.path("items");
+            if (items.size() > 0) {
+                JsonNode firstItem = items.get(0);
+                Integer id = firstItem.get("id").asInt();
+                return id;
+            } else {
+                System.out.println("Could not find contact with idir: " + contactIdir + " in CRM");
+                return null;
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private void generateAndAddPDFForForm(String formId, String submissionId, int crmIncidentId) throws Exception {
+        String pdfEncodedBase64 = generatePDFForForm(formId, submissionId, TEST_PDF);
+        addCrmAttachment(crmIncidentId, pdfEncodedBase64, TEST_PDF);
+        System.out.println("Finished generating and adding PDF for form");
+    }
+
+    private String generatePDFForForm(String formId, String submissionId, String fileName) throws Exception {
+        DataSource pdf = this.attachmentService.generatePdf(formId, submissionId);
+        try (InputStream is = pdf.getInputStream(); ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            int nRead;
+            byte[] data = new byte[1024];
+            while ((nRead = is.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+
+            byte[] bytes = buffer.toByteArray();
+            String encoded = Base64.getEncoder().encodeToString(bytes);
+            return encoded;
+        }
+    }
+
+    private void addCrmAttachment(int crmIncidentId ,String pdfEncodedBase64, String pdfName) {
+        String addCrmAttachmentEndpoint = INCIDENTS +"/" + crmIncidentId + "/fileAttachments";
+        String url = getEndpointUrl(addCrmAttachmentEndpoint);
+        CrmFileAttachmentPostRequest crmFileAttachmentPostRequest = new CrmFileAttachmentPostRequest(pdfName, pdfEncodedBase64);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            ResponseEntity<String> response = httpServiceInvoker.execute(
+                url, HttpMethod.POST, objectMapper.writeValueAsString(crmFileAttachmentPostRequest));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String getCurrentUserIdir(DelegateExecution execution) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
+            Jwt jwt = (Jwt) authentication.getPrincipal();
+            String idir = jwt.getClaimAsString("idir");
+            return idir;
+        }
+        else {
+            System.err.println("No authentication found!");
+            return null;
+        }
+    }
+
+    private String getEndpointUrl(String endpoint) {
+        return crmUrl + "/" + endpoint;
+    }
+
+    private static HashMap<String, String> extractIds(String url) {
+        // The regex pattern to match the formId and submissionId
+        String pattern = ".*/form/(.*?)/submission/(.*)";
+        
+        // Create a Pattern object
+        Pattern r = Pattern.compile(pattern);
+        
+        // Create matcher object
+        Matcher m = r.matcher(url);
+        HashMap<String, String> ids = new HashMap<>();
+
+        if (m.find()) {
+            ids.put("formId", m.group(1));
+            ids.put("submissionId", m.group(2));
+        }
+        return ids;
+    }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -52,7 +52,7 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
     private static final String FORM_URL = "formUrl";
     private static final String INCIDENTS = "incidents";
     private static final String CONTACTS = "contacts";
-    private static final String TEST_PDF = "test.pdf";
+    private static final String ATTACHMENT_FILE_NAME = "attachment.pdf";
 
     @Autowired
     private HTTPServiceInvoker httpServiceInvoker;
@@ -181,9 +181,9 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
     }
 
     private void generateAndAddPDFForForm(String formId, String submissionId, int crmIncidentId) throws Exception {
-        String pdfEncodedBase64 = generatePDFForForm(formId, submissionId, TEST_PDF);
-        addCrmAttachment(crmIncidentId, pdfEncodedBase64, TEST_PDF);
-        System.out.println("Finished generating and adding PDF for form");
+        String pdfEncodedBase64 = generatePDFForForm(formId, submissionId, ATTACHMENT_FILE_NAME);
+        attachment(crmIncidentId, pdfEncodedBase64, ATTACHMENT_FILE_NAME);
+        attachment.out.println("Finished generating and adding PDF for form");
     }
 
     private String generatePDFForForm(String formId, String submissionId, String fileName) throws Exception {

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmFileAttachmentPostRequest.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmFileAttachmentPostRequest.java
@@ -1,0 +1,27 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class CrmFileAttachmentPostRequest {
+  private String fileName;
+  private String data;
+  
+  public CrmFileAttachmentPostRequest(String fileName, String data) {
+    this.fileName = fileName;
+    this.data = data;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }  
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmPostRequest.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmPostRequest.java
@@ -1,0 +1,44 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+import java.util.ArrayList;
+
+public class CrmPostRequest {
+  private PrimaryContact primaryContact;
+  private String subject;
+  private ArrayList<Thread> threads;
+  
+  public CrmPostRequest(PrimaryContact primaryContact, String subject) {
+    this.primaryContact = primaryContact;
+    this.subject = subject;
+  }
+
+  public CrmPostRequest(PrimaryContact primaryContact, String subject, ArrayList<Thread> threads) {
+    this.primaryContact = primaryContact;
+    this.subject = subject;
+    this.threads = threads;
+  }
+
+  public PrimaryContact getPrimaryContact() {
+    return primaryContact;
+  }
+
+  public void setPrimaryContact(PrimaryContact primaryContact) {
+    this.primaryContact = primaryContact;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public ArrayList<Thread> getThreads() {
+    return threads;
+  }
+
+  public void setThreads(ArrayList<Thread> threads) {
+    this.threads = threads;
+  }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmPostResponse.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmPostResponse.java
@@ -1,0 +1,22 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class CrmPostResponse {
+    private int id;
+    private String lookupName;
+    public CrmPostResponse(int id, String lookupName) {
+      this.id = id;
+      this.lookupName = lookupName;
+    }
+    public int getId() {
+        return id;
+    }
+    public void setId(int id) {
+        this.id = id;
+    }
+    public String getLookupName() {
+        return lookupName;
+    }
+    public void setLookupName(String lookupName) {
+        this.lookupName = lookupName;
+    }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/EntryType.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/EntryType.java
@@ -1,0 +1,18 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class EntryType {
+    private int id;
+
+    public EntryType(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+    
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/PrimaryContact.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/PrimaryContact.java
@@ -1,0 +1,17 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class PrimaryContact{
+    private int id;
+
+    public PrimaryContact(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/Thread.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/Thread.java
@@ -1,0 +1,23 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class Thread {
+  private String text;
+  private EntryType entryType;
+
+  public Thread(String text, EntryType entryType) {
+    this.text = text;
+    this.entryType = entryType;
+  }
+  public String getText() {
+    return text;
+  }
+  public void setText(String text) {
+    this.text = text;
+  }
+  public EntryType getEntryType() {
+    return entryType;
+  }
+  public void setEntryType(EntryType entryType) {
+    this.entryType = entryType;
+  }
+}

--- a/forms-flow-bpm/src/main/resources/application.yaml
+++ b/forms-flow-bpm/src/main/resources/application.yaml
@@ -52,6 +52,10 @@ formsflow.ai:
     url: ${WEB_BASE_URL}
   documentApi:
     url: ${FORMSFLOW_DOC_API_URL}
+  crm:
+    url: ${CRM_URL}
+    security:
+      token: ${CRM_AUTH_TOKEN}
 
 
 camunda.bpm:


### PR DESCRIPTION
## Summary

This PR adds a CRM service in Camunda to create a CRM incident (ticket) leveraging its API. #1100 

## Changes
- CRM service is added
- Number Java objects were added for CRM operation

## Screenshots (if applicable)
CRM service can be added as a service task in the Camunda workflow to create a CRM ticket for users who run that workflow. 

<img width="1364" alt="Screenshot 2023-06-23 at 11 46 46 AM" src="https://github.com/bcgov/digital-journeys/assets/77303486/981a3efe-686e-4562-87da-6b938f84f05b">


## Notes
At this point, the service only supports incident creation and saves it to the form. The next steps will involve the ability to update an existing ticket, extracting relevant field in the form and adding them as a thread of text into an incident, and making sure the pdf style and format is according to requirement. These will handle in separate tickets in the future.