### PR TITLE
DGJ-1216 SL Name is cut off in PDF generated online

### DIFF
--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -41,6 +41,15 @@ export const printToPDF = ({ pdfName, formName }) => {
       changeElm.push(elm);
     }
   });
+  /** .show-in-print-only has property display:none 
+  * so no need to check for style.display none or block.
+  */
+  const showInPrint = document.querySelectorAll(".show-in-print-only");
+  let changeHiddenElm = [];
+  showInPrint.forEach((elm) => {
+      elm.style.display = "block";
+      changeHiddenElm.push(elm);
+  });
   // Hiding the floating buttons during the PDF generation
   const selectors = "button.floatingButton,.formio-component-button";
   const floatingButtons = document.querySelectorAll(selectors);
@@ -51,6 +60,8 @@ export const printToPDF = ({ pdfName, formName }) => {
     checkedRadio.forEach((ele) => ele.checked = true);
     floatingButtons.forEach((btmElm) => (btmElm.style.visibility = "visible"));
     changeElm.forEach((elm) => (elm.style.display = "block"));
+    changeHiddenElm.forEach((elm) => (elm.style.display = "none"));
+    changeHiddenElm = [];
     changeElm = [];
     if (appContainer.length > 0) {
       appContainer[0].style.maxWidth = '';


### PR DESCRIPTION
## Summary

DGJ-1216 Senior Leader Name is cut off in the PDF generated online

## Changes
Added script that make block visible if someone click on print button.

## Screenshots (if applicable)
![sl-ss](https://github.com/bcgov/digital-journeys/assets/99269796/3e2e22fb-c0d3-440f-950e-853e5fdeb83c)

## Notes
NA