### PR TITLE
DGJ-1190 Mat-Pat CRM ticket thread integration

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -93,7 +93,6 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         Map<String, String> ids = extractIds(formUrl);
         String formId = ids.get(FORM_ID);
         String submissionId = ids.get(SUBMISSION_ID);
-        String threadText = String.valueOf(execution.getVariables().get(CRM_THREAD_TEXT));
         
         if (formId == null || submissionId == null) {
             System.out.println("formId or submissionId is null. formUrl: " + formUrl + " formId: " + formId + " submissionId" + submissionId);
@@ -121,7 +120,7 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         }
 
         // Create a new incident in CRM
-        CrmPostResponse crmPostResponse = createCrmIncident(contactId, threadText);
+        CrmPostResponse crmPostResponse = createCrmIncident(contactId, execution);
         if (crmPostResponse == null) {
             System.out.println("crmPostResponse is null: " + crmPostResponse);
             throw new ApplicationServiceException("createCrmIncident failed.");
@@ -142,9 +141,10 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         System.out.println("Finished CRM operation");
     }
 
-    private CrmPostResponse createCrmIncident(int contactId, String threadText) {
+    private CrmPostResponse createCrmIncident(int contactId, DelegateExecution execution) {
         String incidentSubject = "Test incident from Camunda";
         CrmPrimaryContact crmPrimaryContact = new CrmPrimaryContact(contactId);
+        String threadText = String.valueOf(execution.getVariables().get(CRM_THREAD_TEXT));
         if (threadText == null) {
             threadText = "";
         }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -18,6 +18,8 @@ import main.java.org.camunda.bpm.extension.hooks.model.CrmFileAttachmentPostRequ
 import main.java.org.camunda.bpm.extension.hooks.model.CrmPostRequest;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmPostResponse;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmEntryType;
+import main.java.org.camunda.bpm.extension.hooks.model.CrmChannel;
+import main.java.org.camunda.bpm.extension.hooks.model.CrmContentType;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmPrimaryContact;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmThread;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmProduct;
@@ -60,6 +62,7 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
     private static final String CRM_LOOKUP_NAME = "crmLookupName";
     private static final String CRM_MAT_PAT_PRODUCT_LOOKUP_NAME = "Leave & Time off";
     private static final String CRM_MAT_PAT_CATEGORY_LOOKUP_NAME = "Maternity, Parental and Adoption Leave";
+    private static final String CRM_THREAD_TEXT = "threadText";
 
     @Autowired
     private HTTPServiceInvoker httpServiceInvoker;
@@ -90,6 +93,7 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         Map<String, String> ids = extractIds(formUrl);
         String formId = ids.get(FORM_ID);
         String submissionId = ids.get(SUBMISSION_ID);
+        String threadText = String.valueOf(execution.getVariables().get(CRM_THREAD_TEXT));
         
         if (formId == null || submissionId == null) {
             System.out.println("formId or submissionId is null. formUrl: " + formUrl + " formId: " + formId + " submissionId" + submissionId);
@@ -117,7 +121,7 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         }
 
         // Create a new incident in CRM
-        CrmPostResponse crmPostResponse = createCrmIncident(contactId);
+        CrmPostResponse crmPostResponse = createCrmIncident(contactId, threadText);
         if (crmPostResponse == null) {
             System.out.println("crmPostResponse is null: " + crmPostResponse);
             throw new ApplicationServiceException("createCrmIncident failed.");
@@ -138,11 +142,16 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
         System.out.println("Finished CRM operation");
     }
 
-    private CrmPostResponse createCrmIncident(int contactId) {
+    private CrmPostResponse createCrmIncident(int contactId, String threadText) {
         String incidentSubject = "Test incident from Camunda";
         CrmPrimaryContact crmPrimaryContact = new CrmPrimaryContact(contactId);
-        CrmEntryType crmEntryType = new CrmEntryType(1);
-        CrmThread crmThread1 = new CrmThread("thread text test 1", crmEntryType); //Todo - later will be extracted from the form submission fields
+        if (threadText == null) {
+            threadText = "";
+        }
+        CrmEntryType crmEntryType = new CrmEntryType(4); // lookupName": "Customer Proxy"
+        CrmChannel crmChannel = new CrmChannel(6); // "lookupName": "CSS Web"
+        CrmContentType crmContentType = new CrmContentType(2); // "lookupName": "text/html", 1 for "text/plain"
+        CrmThread crmThread1 = new CrmThread(threadText, crmEntryType, crmChannel, crmContentType);
         ArrayList<CrmThread> crmThreads = new ArrayList<CrmThread>();
         crmThreads.add(crmThread1);
         CrmProduct crmProduct = new CrmProduct(CRM_MAT_PAT_PRODUCT_LOOKUP_NAME);

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmChannel.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmChannel.java
@@ -1,0 +1,18 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class CrmChannel {
+    private int id;
+
+    public CrmChannel(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+    
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmContentType.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmContentType.java
@@ -1,0 +1,18 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+public class CrmContentType {
+    private int id;
+
+    public CrmContentType(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+    
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmThread.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmThread.java
@@ -3,10 +3,14 @@ package main.java.org.camunda.bpm.extension.hooks.model;
 public class CrmThread {
   private String text;
   private CrmEntryType crmEntryType;
+  private CrmChannel crmChannel;
+  private CrmContentType crmContentType;
 
-  public CrmThread(String text, CrmEntryType crmEntryType) {
+  public CrmThread(String text, CrmEntryType crmEntryType, CrmChannel crmChannel, CrmContentType crmContentType) {
     this.text = text;
     this.crmEntryType = crmEntryType;
+    this.crmChannel = crmChannel;
+    this.crmContentType = crmContentType;
   }
   public String getText() {
     return text;
@@ -19,5 +23,19 @@ public class CrmThread {
   }
   public void setEntryType(CrmEntryType crmEntryType) {
     this.crmEntryType = crmEntryType;
+  }
+
+  public CrmContentType getContentType() {
+    return crmContentType;
+  }
+  public void setContentType(CrmContentType crmContentType) {
+    this.crmContentType = crmContentType;
+  }
+
+  public CrmChannel getChannel() {
+    return crmChannel;
+  }
+  public void setChannel(CrmChannel crmChannel) {
+    this.crmChannel = crmChannel;
   }
 }


### PR DESCRIPTION
## Summary
DGJ-1190 Added Mat-Pat form fields in CRM ticket thread

## Changes
- Added Channel and content type to handle CRM thread configuration
- Added thread with HTML/CSS channel and content type as HTML/TEXT
- Thread text will be calculate on form itself with hidden field `threadText`
- `threadText` should be pass as input param in workflow when invoking crmDelegate.


## Notes
NA