### PR TITLE
DGJ-1279 SL admin group with view all submission rights

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
@@ -20,7 +20,7 @@ from .constants import (
     REVIEWER_GROUP,
     HTTP_TIMEOUT,
     COLD_FLU_ADMIN_GROUP,
-    SL_REVIEW_ADMIN_GROUP
+    SL_REVIEW_ADMIN_GROUP,
 )
 from .enums import ApplicationSortingParameters
 from .format import CustomFormatter

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/__init__.py
@@ -20,7 +20,7 @@ from .constants import (
     REVIEWER_GROUP,
     HTTP_TIMEOUT,
     COLD_FLU_ADMIN_GROUP,
-    SL_REVIEW_ADMIN_GROUP,
+    SL_REVIEW_ADMIN_GROUP
 )
 from .enums import ApplicationSortingParameters
 from .format import CustomFormatter

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/constants.py
@@ -15,7 +15,7 @@ DESIGNER_GROUP = "formsflow-designer"
 REVIEWER_GROUP = "formsflow-reviewer"
 CLIENT_GROUP = "formsflow-client"
 COLD_FLU_ADMIN_GROUP = "cold-flu-admin"
-SL_REVIEW_ADMIN_GROUP = "sl-review-adm"
+SL_REVIEW_ADMIN_GROUP = "sl-review-admin"
 FORMSFLOW_ROLES = [DESIGNER_GROUP, REVIEWER_GROUP, CLIENT_GROUP]
 ALLOW_ALL_APPLICATIONS = "/formsflow/formsflow-reviewer/access-allow-applications"
 

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
@@ -37,7 +37,7 @@ class FormioRoles(Enum):
     ANONYMOUS = "anonymous"
     RESOURCE_ID = "RESOURCE_ID"
     COLD_FLU_ADMIN = "cold-flu-admin"
-    SL_REVIEW_ADMIN = "sl-review-adm"
+    SL_REVIEW_ADMIN = "sl-review-admin"
 
     @classmethod
     def contains(cls, item: str) -> bool:

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/enums.py
@@ -37,6 +37,7 @@ class FormioRoles(Enum):
     ANONYMOUS = "anonymous"
     RESOURCE_ID = "RESOURCE_ID"
     COLD_FLU_ADMIN = "cold-flu-admin"
+    SL_REVIEW_ADMIN = "sl-review-adm"
 
     @classmethod
     def contains(cls, item: str) -> bool:

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -105,9 +105,6 @@ def get_role_ids_from_user_groups(role_ids, user_role):
     """Filters out formio role ids specific to user groups."""
     if user_role is None or user_role is None:
         raise ValueError("Inavlid arguments passed")
-    print("user_role")
-    print(user_role)
-    print(role_ids)
     if DESIGNER_GROUP in user_role:
         return role_ids
     if REVIEWER_GROUP in user_role:
@@ -115,7 +112,6 @@ def get_role_ids_from_user_groups(role_ids, user_role):
     if COLD_FLU_ADMIN_GROUP in user_role:
         return find_matching_roles([FormioRoles.COLD_FLU_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
     if SL_REVIEW_ADMIN_GROUP in user_role:
-        print(find_matching_roles([FormioRoles.SL_REVIEW_ADMIN.name, FormioRoles.CLIENT.name], role_ids))
         return find_matching_roles([FormioRoles.SL_REVIEW_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
     if CLIENT_GROUP in user_role:
         return filter_list_by_user_role(FormioRoles.CLIENT.name, role_ids)
@@ -130,10 +126,6 @@ def find_matching_roles(user_role, role_ids):
     matching_roles = []
 
     for role in role_ids:
-        print("role['type'].upper()")
-        print(role['type'].upper())
-        print(user_role_item.upper() for user_role_item in user_role)
-
         if role['type'].upper() in (user_role_item.upper() for user_role_item in user_role):
             matching_roles.append(role)
 

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -16,6 +16,7 @@ from .constants import (
     DESIGNER_GROUP,
     REVIEWER_GROUP,
     COLD_FLU_ADMIN_GROUP,
+    SL_REVIEW_ADMIN_GROUP
 )
 from .enums import (
     ApplicationSortingParameters,
@@ -111,6 +112,8 @@ def get_role_ids_from_user_groups(role_ids, user_role):
         return filter_list_by_user_role(FormioRoles.REVIEWER.name, role_ids)
     if COLD_FLU_ADMIN_GROUP in user_role:
         return find_matching_roles([FormioRoles.COLD_FLU_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
+    if SL_REVIEW_ADMIN_GROUP in user_role:
+        return find_matching_roles([FormioRoles.SL_REVIEW_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
     if CLIENT_GROUP in user_role:
         return filter_list_by_user_role(FormioRoles.CLIENT.name, role_ids)
     return None

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -105,7 +105,7 @@ def get_role_ids_from_user_groups(role_ids, user_role):
     """Filters out formio role ids specific to user groups."""
     if user_role is None or user_role is None:
         raise ValueError("Inavlid arguments passed")
-
+    print(user_role)
     if DESIGNER_GROUP in user_role:
         return role_ids
     if REVIEWER_GROUP in user_role:
@@ -113,6 +113,7 @@ def get_role_ids_from_user_groups(role_ids, user_role):
     if COLD_FLU_ADMIN_GROUP in user_role:
         return find_matching_roles([FormioRoles.COLD_FLU_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
     if SL_REVIEW_ADMIN_GROUP in user_role:
+        print(find_matching_roles([FormioRoles.SL_REVIEW_ADMIN.name, FormioRoles.CLIENT.name], role_ids))
         return find_matching_roles([FormioRoles.SL_REVIEW_ADMIN.name, FormioRoles.CLIENT.name], role_ids)
     if CLIENT_GROUP in user_role:
         return filter_list_by_user_role(FormioRoles.CLIENT.name, role_ids)

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -105,7 +105,9 @@ def get_role_ids_from_user_groups(role_ids, user_role):
     """Filters out formio role ids specific to user groups."""
     if user_role is None or user_role is None:
         raise ValueError("Inavlid arguments passed")
+    print("user_role")
     print(user_role)
+    print(role_ids)
     if DESIGNER_GROUP in user_role:
         return role_ids
     if REVIEWER_GROUP in user_role:
@@ -128,6 +130,10 @@ def find_matching_roles(user_role, role_ids):
     matching_roles = []
 
     for role in role_ids:
+        print("role['type'].upper()")
+        print(role['type'].upper())
+        print(user_role_item.upper() for user_role_item in user_role)
+
         if role['type'].upper() in (user_role_item.upper() for user_role_item in user_role):
             matching_roles.append(role)
 

--- a/forms-flow-api/src/formsflow_api/resources/application.py
+++ b/forms-flow-api/src/formsflow_api/resources/application.py
@@ -12,6 +12,7 @@ from formsflow_api_utils.utils import (
     get_form_and_submission_id_from_form_url,
     profiletime,
     COLD_FLU_ADMIN_GROUP,
+    SL_REVIEW_ADMIN_GROUP
 )
 from marshmallow.exceptions import ValidationError
 
@@ -85,10 +86,19 @@ class ApplicationsResource(Resource):
                     page_no=page_no,
                     limit=limit,
                 )
-            elif auth.has_role([COLD_FLU_ADMIN_GROUP]):
-                influenza_worksite_process_key = current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY")
-                if influenza_worksite_process_key is None:
-                    current_app.logger.warning("INFLUENZA_WORKSITE_PROCESS_KEY is not set")
+            elif (auth.has_role([COLD_FLU_ADMIN_GROUP]) or 
+                  auth.has_role([SL_REVIEW_ADMIN_GROUP])):
+                role_process_keys = {
+                    COLD_FLU_ADMIN_GROUP: current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY"),
+                    SL_REVIEW_ADMIN_GROUP: current_app.config.get("SL_REVIEW_PROCESS_KEY")
+                }
+                process_keys_filter = []
+                for key, value in role_process_keys.items():
+                    if auth.has_role([key]):
+                        if value is None:
+                            current_app.logger.warning(f"{key} related process key is not set")
+                        else:
+                            process_keys_filter.append(value)
                 (
                     application_schema_dump,
                     application_count,
@@ -107,8 +117,34 @@ class ApplicationsResource(Resource):
                     token=request.headers["Authorization"],
                     page_no=page_no,
                     limit=limit,
-                    process_keys=[influenza_worksite_process_key],
+                    process_keys=process_keys_filter,
                 )
+            # elif auth.has_role([COLD_FLU_ADMIN_GROUP]):
+            #     influenza_worksite_process_key = current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY")
+            #     print("influenza_worksite_process_key")
+            #     print(influenza_worksite_process_key)
+            #     if influenza_worksite_process_key is None:
+            #         current_app.logger.warning("INFLUENZA_WORKSITE_PROCESS_KEY is not set")
+            #     (
+            #         application_schema_dump,
+            #         application_count,
+            #         draft_count,
+            #     ) = ApplicationService.get_all_applications_by_user_by_process_keys_and_count(
+            #         created_from=created_from_date,
+            #         created_to=created_to_date,
+            #         modified_from=modified_from_date,
+            #         modified_to=modified_to_date,
+            #         order_by=order_by,
+            #         sort_order=sort_order,
+            #         created_by=created_by,
+            #         application_id=application_id,
+            #         application_name=application_name,
+            #         application_status=application_status,
+            #         token=request.headers["Authorization"],
+            #         page_no=page_no,
+            #         limit=limit,
+            #         process_keys=[influenza_worksite_process_key],
+            #     )
             else:
                 (
                     application_schema_dump,

--- a/forms-flow-api/src/formsflow_api/resources/application.py
+++ b/forms-flow-api/src/formsflow_api/resources/application.py
@@ -119,32 +119,6 @@ class ApplicationsResource(Resource):
                     limit=limit,
                     process_keys=process_keys_filter,
                 )
-            # elif auth.has_role([COLD_FLU_ADMIN_GROUP]):
-            #     influenza_worksite_process_key = current_app.config.get("INFLUENZA_WORKSITE_PROCESS_KEY")
-            #     print("influenza_worksite_process_key")
-            #     print(influenza_worksite_process_key)
-            #     if influenza_worksite_process_key is None:
-            #         current_app.logger.warning("INFLUENZA_WORKSITE_PROCESS_KEY is not set")
-            #     (
-            #         application_schema_dump,
-            #         application_count,
-            #         draft_count,
-            #     ) = ApplicationService.get_all_applications_by_user_by_process_keys_and_count(
-            #         created_from=created_from_date,
-            #         created_to=created_to_date,
-            #         modified_from=modified_from_date,
-            #         modified_to=modified_to_date,
-            #         order_by=order_by,
-            #         sort_order=sort_order,
-            #         created_by=created_by,
-            #         application_id=application_id,
-            #         application_name=application_name,
-            #         application_status=application_status,
-            #         token=request.headers["Authorization"],
-            #         page_no=page_no,
-            #         limit=limit,
-            #         process_keys=[influenza_worksite_process_key],
-            #     )
             else:
                 (
                     application_schema_dump,

--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -12,6 +12,7 @@ from formsflow_api_utils.utils import (
     DESIGNER_GROUP,
     REVIEWER_GROUP,
     COLD_FLU_ADMIN_GROUP,
+    SL_REVIEW_ADMIN_GROUP,
     auth,
     cache,
     cors_preflight,
@@ -53,6 +54,8 @@ class FormioResource(Resource):
                 filter_list.append(FormioRoles.CLIENT.name)
             if COLD_FLU_ADMIN_GROUP in user.roles:
                 filter_list.append(FormioRoles.COLD_FLU_ADMIN.name)
+            if SL_REVIEW_ADMIN_GROUP in user.roles:
+                filter_list.append(FormioRoles.SL_REVIEW_ADMIN.name)
             return item["type"] in filter_list
 
         @after_this_request

--- a/forms-flow-forms/formsflow-template.json
+++ b/forms-flow-forms/formsflow-template.json
@@ -39,6 +39,12 @@
       "description": "A person who can view all cold-flu form submissions.",
       "admin": false,
       "default": false
+    },
+    "sl-review-admin": {
+      "title": "sl-review-admin",
+      "description": "A person who can view all SL review form submissions.",
+      "admin": false,
+      "default": false
     }
   },
   "forms": {

--- a/forms-flow-web/src/components/Application/List.js
+++ b/forms-flow-web/src/components/Application/List.js
@@ -58,6 +58,7 @@ export const ApplicationList = React.memo(() => {
   // const draftCount = useSelector((state) => state.draft.draftCount);
   const dispatch = useDispatch();
   const userRoles = useSelector((state) => state.user.roles);
+  const userObj = useSelector((state) => state.user.userDetail);
   const page = useSelector((state) => state.applications.activePage);
   const iserror = useSelector((state) => state.applications.iserror);
   const error = useSelector((state) => state.applications.error);
@@ -147,6 +148,8 @@ export const ApplicationList = React.memo(() => {
   const listApplications = (applications) => {
     let totalApplications = applications.map((application) => {
       application.isClientEdit = isClientEdit(application.applicationStatus);
+      application.loggedInUserObj = userObj;
+      application.userRoles = userRoles;
       return application;
     });
     return totalApplications;

--- a/forms-flow-web/src/components/Application/table.js
+++ b/forms-flow-web/src/components/Application/table.js
@@ -18,6 +18,7 @@ import { useDispatch } from "react-redux";
 import {
   SL_REVIEW_PROCESS_KEY,
   INFLUENZA_WORKSITE_PROCESS_KEY,
+  SL_REVIEW_ADMIN_GROUP
 } from "../../constants/constants";
 
 let statusFilter, idFilter, nameFilter, modifiedDateFilter;
@@ -54,6 +55,21 @@ export const defaultSortedBy = [
 // eslint-disable-next-line
 const LinkSubmission = React.memo(({ cell, row, redirectUrl }) => {
   const dispatch = useDispatch();
+
+  const checkRolesViewOlny = [SL_REVIEW_ADMIN_GROUP];
+  const assignedSelectedRoles = checkRolesViewOlny.filter(value => row.userRoles.includes(value));
+  const allowedProcessKeysForViewOlny = [
+    SL_REVIEW_PROCESS_KEY
+  ];
+  let isViewOnly = false;
+  const isSubmissionOwner = row.submission.owner === row.loggedInUserObj.email;
+  if (assignedSelectedRoles.length > 0 &&
+    row.isClientEdit && 
+    allowedProcessKeysForViewOlny.some((el) => el === row.processKey) && 
+    !isSubmissionOwner) {
+    row.isClientEdit = false;
+    isViewOnly = true;
+  }
   const url = row.isClientEdit
     ? `${redirectUrl}form/${row.formId}/submission/${row.submissionId}/edit`
     : `${redirectUrl}form/${row.formId}/submission/${row.submissionId}`;
@@ -102,7 +118,7 @@ const LinkSubmission = React.memo(({ cell, row, redirectUrl }) => {
           </span>
         </div>
       </div>
-      {allowedProcessKeysForDeletion.some((el) => el === row.processKey) && (
+      {allowedProcessKeysForDeletion.some((el) => el === row.processKey) && !isViewOnly && (
         <div
           style={{ textDecoration: "none", marginLeft: "16px" }}
           onClick={() => handleDeleteApplication(row)}

--- a/forms-flow-web/src/constants/constants.js
+++ b/forms-flow-web/src/constants/constants.js
@@ -66,6 +66,7 @@ export const ANONYMOUS_USER = "anonymous";
 
 export const MANAGER_GROUP = 'manager';
 export const COLD_FLU_ADMIN_GROUP = 'cold-flu-admin';
+export const SL_REVIEW_ADMIN_GROUP = 'sl-review-admin';
 
 export const FORMIO_JWT_SECRET =
   (window._env_ && window._env_.REACT_APP_FORMIO_JWT_SECRET) || process.env.REACT_APP_FORMIO_JWT_SECRET || "--- change me now ---";


### PR DESCRIPTION
## Summary

DGJ-1279 Allow group of SL review admin to view and print submissions

## Changes
- Added code that can extend for view only on WEB
- Added sl-review-admin group and key to allow user to fetch application list
- Added formio roles for sl-review-admin in utils.
- Added sl-review-admin in formio formflow-template.json file


## Notes
NA