### PR TITLE
DGJ-1291 in edit form, Print to PDF is trim text and show only 1st line

### DIFF
--- a/forms-flow-web/src/services/PdfService.js
+++ b/forms-flow-web/src/services/PdfService.js
@@ -32,6 +32,19 @@ export const printToPDF = ({ pdfName, formName }) => {
     appContainer[0].style.maxWidth = maxWidth;
     appContainer[0].style.minWidth = maxWidth;
   }
+  //hide textarea at the time of print ticket#1291
+  const textAreas = document.querySelectorAll('textarea.form-control');
+  let changeTextAreasElm = [];
+  textAreas.forEach((elm) => {
+    if (elm.style.display === "" || elm.style.display === "block") {
+      elm.insertAdjacentHTML(
+        "afterend",
+        `<div class="textarea-edit-print-only form-control" style="height:auto">${elm.value}</div>`
+      );
+      elm.style.display = "none";
+      changeTextAreasElm.push(elm);
+    }
+  });
   // hide block with class .hidden-in-print
   const hiddenInPrint = document.querySelectorAll(".hidden-in-print");
   let changeElm = [];
@@ -63,6 +76,11 @@ export const printToPDF = ({ pdfName, formName }) => {
     changeHiddenElm.forEach((elm) => (elm.style.display = "none"));
     changeHiddenElm = [];
     changeElm = [];
+    // visible textarea again and remove additional temp div ticket#1291
+    const textareaEditPrintOnly = document.querySelectorAll(".textarea-edit-print-only");
+    textareaEditPrintOnly.forEach((elm) => elm.remove());
+    changeTextAreasElm.forEach((elm) => (elm.style.display = "block"));
+    changeTextAreasElm = [];
     if (appContainer.length > 0) {
       appContainer[0].style.maxWidth = '';
       appContainer[0].style.minWidth = '';


### PR DESCRIPTION
## Summary

DGJ-1291 in edit form, Print to PDF is trim text and show only 1st line

## Changes
- Select all text area field and hide at the time of print.
- Pull text from text area and add in DIV
- Remove temp divs for text and Show textarea again.


## Notes
NA