### PR TITLE
Currency calculator popup was fixed

### DIFF
--- a/forms-flow-web/src/formComponents/CurrencyComponent/index.js
+++ b/forms-flow-web/src/formComponents/CurrencyComponent/index.js
@@ -11,7 +11,7 @@ const CurrencyComponent = Components.components.currency;
 export default class DGJCurrencyComponent extends CurrencyComponent {
     attach(element) {
         const webForm = this;
-        const tooltipInfoButton = element?.children[0]?.children[0];
+        const tooltipInfoButton = element?.children[0]?.children[1];
         const tooltipHtmlText = webForm.component.tooltip;
         // By contract, form designer should add the following
         // popup html comment in the tooltip text to force it to be opened as a popup


### PR DESCRIPTION
## Summary

This PR fixed the issue with the `DGJCurrencyComponent` popup. 

## Changes
- Loaded children element was changed

## Screenshots (if applicable)

<img width="1057" alt="Screenshot 2023-09-10 at 8 57 51 PM" src="https://github.com/bcgov/digital-journeys/assets/77303486/27433f2c-1ccd-4a2c-9c69-791a3d796e2c">

## Note

The fixed was kinely provided by Bhumin :)
