### PR TITLE
DGJ_895-mat_pat-new-status

### DIFF
--- a/forms-flow-web/src/components/Application/List.js
+++ b/forms-flow-web/src/components/Application/List.js
@@ -27,7 +27,7 @@ import {
   MULTITENANCY_ENABLED,
   STAFF_REVIEWER,
 } from "../../constants/constants";
-import { CLIENT_EDIT_STATUS } from "../../constants/applicationConstants";
+// import { CLIENT_EDIT_STATUS } from "../../constants/applicationConstants";
 import Alert from "react-bootstrap/Alert";
 import { Translation } from "react-i18next";
 
@@ -39,6 +39,7 @@ import { push } from "connected-react-router";
 import Confirm from "../../containers/Confirm";
 import { toast } from "react-toastify";
 import LoadingOverlay from "react-loading-overlay";
+import { hasFormEditAccessByStatus } from "../../helper/access";
 
 export const ApplicationList = React.memo(() => {
   const { t } = useTranslation();
@@ -95,12 +96,13 @@ export const ApplicationList = React.memo(() => {
     dispatch(getAllApplications(currentPage.current, countPerPageRef.current));
   }, [dispatch, currentPage, countPerPageRef, isDeletingApplication]);
 
-  const isClientEdit = (applicationStatus) => {
+  const isClientEdit = (applicationStatus, formName) => {
     if (
       getUserRolePermission(userRoles, CLIENT) ||
       getUserRolePermission(userRoles, STAFF_REVIEWER)
     ) {
-      return CLIENT_EDIT_STATUS.includes(applicationStatus);
+      return hasFormEditAccessByStatus(formName, applicationStatus);
+      // return CLIENT_EDIT_STATUS.includes(applicationStatus);
     } else {
       return false;
     }
@@ -147,7 +149,8 @@ export const ApplicationList = React.memo(() => {
 
   const listApplications = (applications) => {
     let totalApplications = applications.map((application) => {
-      application.isClientEdit = isClientEdit(application.applicationStatus);
+      application.isClientEdit = isClientEdit(application.applicationStatus, 
+        application.applicationName);
       application.loggedInUserObj = userObj;
       application.userRoles = userRoles;
       return application;

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -25,7 +25,7 @@ import {
   MULTITENANCY_ENABLED,
 } from "../../../../../constants/constants";
 import {
-  CLIENT_EDIT_STATUS,
+  // CLIENT_EDIT_STATUS,
   UPDATE_EVENT_STATUS,
   getProcessDataReq,
 } from "../../../../../constants/applicationConstants";
@@ -55,6 +55,7 @@ import { getTaskSubmitFormReq } from "../../../../../apiManager/services/bpmServ
 import { redirectToSuccessPage } from "../../../../../constants/successTypes";
 import { CUSTOM_EVENT_TYPE } from "../../../../ServiceFlow/constants/customEventTypes";
 import { printToPDF } from "../../../../../services/PdfService";
+import { hasFormEditAccessByStatus } from "../../../../../helper/access";
 
 const Edit = React.memo((props) => {
   const { t } = useTranslation();
@@ -102,7 +103,8 @@ const Edit = React.memo((props) => {
     if (applicationStatus && !onFormSubmit) {
       if (
         getUserRolePermission(userRoles, CLIENT) &&
-        !CLIENT_EDIT_STATUS.includes(applicationStatus)
+        // !CLIENT_EDIT_STATUS.includes(applicationStatus)
+        !hasFormEditAccessByStatus(applicationDetail?.applicationName, applicationStatus)
         ) {
         dispatch(push(`/form/${formId}/submission/${submissionId}`));
       }

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/index.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/index.js
@@ -16,10 +16,11 @@ import {
   STAFF_REVIEWER,
   EDIT_SUBMISSION_PAGE,
 } from "../../../../../constants/constants";
-import { CLIENT_EDIT_STATUS } from "../../../../../constants/applicationConstants";
+// import { CLIENT_EDIT_STATUS } from "../../../../../constants/applicationConstants";
 import Loading from "../../../../../containers/Loading";
 import { clearSubmissionError } from "../../../../../actions/formActions";
 import { getCustomSubmission } from "../../../../../apiManager/services/FormServices";
+import { hasFormEditAccessByStatus } from "../../../../../helper/access";
 
 const Item = React.memo(() => {
   const { formId, submissionId } = useParams();
@@ -42,6 +43,10 @@ const Item = React.memo(() => {
 
   // const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : `/`
 
+  const applicationDetail = useSelector(
+    (state) => state.applications.applicationDetail
+  );
+
   useEffect(() => {
     dispatch(clearSubmissionError("submission"));
     if(CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {
@@ -63,7 +68,9 @@ const Item = React.memo(() => {
       setEditAllowed(true);
     } else if (applicationStatus) {
       if (getUserRolePermission(userRoles, CLIENT)) {
-        setEditAllowed(CLIENT_EDIT_STATUS.includes(applicationStatus));
+        // setEditAllowed(CLIENT_EDIT_STATUS.includes(applicationStatus));
+        setEditAllowed(hasFormEditAccessByStatus(applicationDetail?.applicationName, 
+          applicationStatus));
         setShowSubmissionLoading(false);
       }
     }

--- a/forms-flow-web/src/constants/applicationConstants.js
+++ b/forms-flow-web/src/constants/applicationConstants.js
@@ -9,8 +9,13 @@ export const RESUBMITTED_STATUS = "Resubmitted";
 export const VALIDATED_STATUS = "Validated";
 export const SUBMITTED_VALIDATION_STATUS = "Submitted - Validation";
 export const SUBMITTED_FINAL_STATUS = "Submitted - Final";
+export const APPROVED_STATUS = "APPROVED";
+export const DENIED_STATUS = "DENIED";
+export const NEW_STATUS = "NEW";
+export const COMPLETED_STATUS = "Completed";
 
-export const CLIENT_EDIT_STATUS = [
+// No longer need this, as edit access is now controlled by the formEditStatusMap in forms-flow-web/src/helper/access.js
+/* export const CLIENT_EDIT_STATUS = [
   AWAITING_ACKNOWLEDGEMENT,
   RESUBMIT_STATUS,
   SUBMITTED_STATUS,
@@ -18,7 +23,7 @@ export const CLIENT_EDIT_STATUS = [
   VALIDATED_STATUS,
   SUBMITTED_VALIDATION_STATUS,
   SUBMITTED_FINAL_STATUS,
-];
+]; */
 
 export const UPDATE_EVENT_STATUS = [RESUBMIT_STATUS, AWAITING_ACKNOWLEDGEMENT];
 

--- a/forms-flow-web/src/constants/formConstants.js
+++ b/forms-flow-web/src/constants/formConstants.js
@@ -4,6 +4,7 @@ export const FORM_NAMES = {
     TELEWORK: 'Telework agreement',
     COMPLIANT_1_10: 'Bullying / Misuse of Authority Complaint Form (Article 1.10)',
     INFLUENZA_WORKSITE_REGISTRATION: '2023 Influenza Worksite Registration',
+    MATERNITY_AND_PARENTAL_LEAVE_FORM: 'Maternity and parental leave form'
   };
   /** 
    * please review "Form display name in draft and submission list" on below link

--- a/forms-flow-web/src/helper/access.js
+++ b/forms-flow-web/src/helper/access.js
@@ -1,3 +1,12 @@
+import { FORM_NAMES } from "../constants/formConstants";
+import { 
+  SUBMITTED_STATUS,
+  SUBMITTED_VALIDATION_STATUS,
+  SUBMITTED_FINAL_STATUS,
+  APPROVED_STATUS,
+  DENIED_STATUS,
+  NEW_STATUS, } from "../constants/applicationConstants";
+import { convertObjectKeyValueToLowercase } from './helper';
 /**
  * 
  * @param {String} type 
@@ -76,4 +85,23 @@ export const setFormAndSubmissionAccess = (type, data) => {
     default:
       break;
   }
+};
+
+/* Status of the forms that once submitted can support edit under Submitted Forms page
+  * Those not listed, will only support view submission
+*/
+const formEditStatusMap = {
+  [FORM_NAMES.MATERNITY_AND_PARENTAL_LEAVE_FORM]: [NEW_STATUS, APPROVED_STATUS, DENIED_STATUS],
+  [FORM_NAMES.INFLUENZA_WORKSITE_REGISTRATION]: [SUBMITTED_STATUS],
+  [FORM_NAMES.SL_REVIEW]: [SUBMITTED_VALIDATION_STATUS, SUBMITTED_FINAL_STATUS],
+};
+
+export const hasFormEditAccessByStatus = (formName, status) => {
+  // convert form names and status to lowercase for comparison
+  const lowerCaseFormName = formName.toLowerCase();
+  const lowerCaseStatus = status.toLowerCase();
+  const lowerCaseFormEditStatusMap = convertObjectKeyValueToLowercase(formEditStatusMap);
+  
+  const validStatuses = lowerCaseFormEditStatusMap[lowerCaseFormName] || [];
+  return validStatuses.includes(lowerCaseStatus);
 };

--- a/forms-flow-web/src/helper/helper.js
+++ b/forms-flow-web/src/helper/helper.js
@@ -69,10 +69,35 @@ const getEmployeeNameFromSubmission = (form, submission) => {
   return submitterName ? submitterName.trim() : "";
 };
 
+function convertObjectKeyValueToLowercase(obj) {
+  if (typeof obj !== 'object') {
+    throw new Error('Input is not an object');
+  }
+
+  const result = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (Array.isArray(value)) {
+      result[key.toLowerCase()] = value.map((item) =>
+        typeof item === 'string' ? item.toLowerCase() : item
+      );
+    } else if (typeof value === 'string') {
+      result[key.toLowerCase()] = value.toLowerCase();
+    } else if (typeof value === 'object') {
+      result[key.toLowerCase()] = convertObjectKeyValueToLowercase(value);
+    } else {
+      result[key.toLowerCase()] = value;
+    }
+  }
+
+  return result;
+}
+
 export {
   replaceUrl,
   addTenankey,
   removeTenantKey,
   checkAndAddTenantKey,
   getEmployeeNameFromSubmission,
+  convertObjectKeyValueToLowercase
 };


### PR DESCRIPTION
## Summary

This PR adds a new form edit access system that allows each form to control which status should be allowed for user access. #895 

## Changes
- Replacing the list of status that supports editing, with a new form-mapper that allow each form to control its status for edit submission access
- Updated the components that deal with edit submission to work with the new access system.
- Added new status to the Mat/Pat form: (`NEW`, `APPROVED` and `DENIED`)
- Apart from this PR, the mat/pat form was updated to support the new status and its workflow now has `status` as part of the task name displayed in the list under the `/task` page.