### PR TITLE
DGJ_1349-open-links-in-new-tabs

### DIFF
--- a/forms-flow-web/src/components/Draft/Edit.js
+++ b/forms-flow-web/src/components/Draft/Edit.js
@@ -65,7 +65,6 @@ const View = React.memo((props) => {
     (state) => state.formDelete.formSubmitted
   );
 
-  const [areFormLinksWereConverted, setAreFormLinksWereConverted] = React.useState(false);
   const formRef = useRef(null);
   const isPublic = !props.isAuthenticated;
   const tenantKey = useSelector((state) => state.tenants?.tenantId);
@@ -152,23 +151,6 @@ const View = React.memo((props) => {
       if (poll) saveDraft(payload, exitType.current);
     };
   }, [poll, exitType.current, draftSubmission]);
-
-  let convertFormLinksInterval = null;
-  useEffect(() => {
-    if (areFormLinksWereConverted) {
-      return; 
-    }
-    convertFormLinksInterval = setInterval(() => {
-      const done = convertFormLinksToOpenInNewTabs(
-        formRef.current?.formio,
-        convertFormLinksInterval
-      );
-      setAreFormLinksWereConverted(done);
-    }, 1000);
-    return () => {
-      clearInterval(convertFormLinksInterval);
-    };
-  });
 
   /* Pass values to the form components
    A component with the same key should be present in the form otherwise it will be ignored */
@@ -434,6 +416,12 @@ const doProcessActions = (submission, ownProps) => {
 };
 
 const mapStateToProps = (state) => {
+  // Get form data from state and preprocess it before passed to be rendered
+  const { form } = selectRoot("form", state);
+  if (form._id) {
+    convertFormLinksToOpenInNewTabs(form);
+  }
+  
   return {
     user: state.user.userDetail,
     authToken: state.user.bearerToken,

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/Edit.js
@@ -138,19 +138,6 @@ const Edit = React.memo((props) => {
     };
   });
 
-  let convertFormLinksInterval = null;
-  useEffect(() => {
-    convertFormLinksInterval = setInterval(() => {
-      convertFormLinksToOpenInNewTabs(
-        formRef.current?.formio,
-        convertFormLinksInterval
-      );
-    }, 1000);
-    return () => {
-      clearInterval(convertFormLinksInterval);
-    };
-  });
-
   /* Pass values to the form components
    A component with the same key should be present in the form otherwise it will be ignored */
   let valueForComponentsInterval = null;
@@ -333,6 +320,12 @@ Edit.defaultProps = {
 };
 
 const mapStateToProps = (state) => {
+  // Get form data from state and preprocess it before passed to be rendered
+  const { form } = selectRoot("form", state);
+  if (form._id) {
+    convertFormLinksToOpenInNewTabs(form);
+  }
+
   return {
     user: state.user.userDetail,
     authToken: state.user.bearerToken,

--- a/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Item/View.js
@@ -60,19 +60,6 @@ const View = React.memo((props) => {
     };
   });
 
-  let convertFormLinksInterval = null;
-  useEffect(() => {
-    convertFormLinksInterval = setInterval(() => {
-      convertFormLinksToOpenInNewTabs(
-        formRef.current?.formio,
-        convertFormLinksInterval
-      );
-    }, 1000);
-    return () => {
-      clearInterval(convertFormLinksInterval);
-    };
-  });
-
   let updatedSubmission;
   if (CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {
     updatedSubmission = customSubmission;
@@ -126,6 +113,12 @@ const View = React.memo((props) => {
 //   showPrintButton: true,
 // };
 const mapStateToProps = (state, props) => {
+  // Get form data from state and preprocess it before passed to be rendered
+  const { form } = selectRoot("form", state);
+  if (form._id) {
+    convertFormLinksToOpenInNewTabs(form);
+  }
+  
   const isDraftView = props.page === "draft-detail" ? true : false;
   return {
     form: selectRoot("form", state),

--- a/forms-flow-web/src/components/Form/Item/View.js
+++ b/forms-flow-web/src/components/Form/Item/View.js
@@ -70,7 +70,6 @@ import MessageModal from "../../../containers/MessageModal";
 
 const View = React.memo((props) => {
   const [formStatus, setFormStatus] = React.useState("");
-  const [areFormLinksWereConverted, setAreFormLinksWereConverted] = React.useState(false);
   const { t } = useTranslation();
   const lang = useSelector((state) => state.user.lang);
   const formStatusLoading = useSelector(
@@ -348,26 +347,6 @@ const View = React.memo((props) => {
     setDefaultVals(getDefaultValues(employeeData.data, form));
   }, [employeeData.data, form]);
 
-  let convertFormLinksInterval = null;
-  useEffect(() => {
-    if (areFormLinksWereConverted) {
-      return; 
-    }
-    convertFormLinksInterval = setInterval(() => {
-      /* check formRef before calling function of formio */
-      if (formRef.current !== null) {
-        const done = convertFormLinksToOpenInNewTabs(
-          formRef.current?.formio,
-          convertFormLinksInterval
-        );
-        setAreFormLinksWereConverted(done);
-      }
-    }, 1000);
-    return () => {
-      clearInterval(convertFormLinksInterval);
-    };
-  });
-
   /* Pass values to the form components
    A component with the same key should be present in the form otherwise it will be ignored */
   let valueForComponentsInterval = null;
@@ -477,8 +456,6 @@ const View = React.memo((props) => {
         return;
     }
   };
-
-
 
   return (
     <div className="container overflow-y-auto">
@@ -671,6 +648,12 @@ const doProcessActions = (submission, ownProps) => {
 };
 
 const mapStateToProps = (state) => {
+  // Get form data from state and preprocess it before passed to be rendered
+  const { form } = selectRoot("form", state);
+  if (form._id) {
+    convertFormLinksToOpenInNewTabs(form);
+  }
+  
   return {
     user: state.user.userDetail,
     authToken: state.user.bearerToken,

--- a/forms-flow-web/src/helper/formUtils.js
+++ b/forms-flow-web/src/helper/formUtils.js
@@ -1,18 +1,18 @@
+import Utils from 'formiojs/utils';
 
-const convertFormLinksToOpenInNewTabs = (formio, convertFormLinksInterval) => {
-  if (formio) {
-    clearInterval(convertFormLinksInterval);
-    formio.everyComponent((component) => {
-      if (component.component.html) {
-        component.component.html = component.component.html.replace(
+const convertFormLinksToOpenInNewTabs = (form) => {
+  Utils.eachComponent(
+    form.components,
+    (component) => {
+      if (component.html) {
+        component.html = component.html.replace(
           /<a\s+href=/gi,
           '<a target="_blank" href='
         );
       }
-    });
-  }
-  formio.redraw();
-  return true;
+    },
+    true
+  );
 };
 
 const setValueForComponents = (formio, valueForComponentsInterval, keyValuePairs) => {
@@ -194,5 +194,5 @@ export {
   getDefaultValues,
   getFormSupportedIDPFromJSON, 
   setValueForComponents,
-  mergeFormioAccessRoles,
+  mergeFormioAccessRoles
 };


### PR DESCRIPTION
## Summary
This PR (#1349) improves the existing function that converts all the form's links to open in new tabs. Instead of modifying the live form after it's been rendered, it changes the links before the form is rendered (changes the static form). This will ensure all the links even those that are conditionally rendered in the line form (used to miss the _blank attribute) are opening in new tabs.

One improvement over my approach would be to modify the form right after/before added to the state. I wasn't able to find the right place where Redux adds form to the app state and instead changes the form state in each component (e.g., view, draft, edit submission etc). Please let me know if you know how to change the form there so we modify the form in one place instead of all view/edit/draft files.

