### PR TITLE
DGJ-1381 send an email to supervisor when CRM ticket update

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -25,6 +25,7 @@ import main.java.org.camunda.bpm.extension.hooks.model.CrmCustomFields;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmC;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmReferenceContactPostRequest;
 import main.java.org.camunda.bpm.extension.hooks.model.CrmStatusWithType;
+import main.java.org.camunda.bpm.extension.hooks.model.CrmIncidentPatchRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -242,7 +243,14 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
                 System.out.println("Update CRM incident with ID :" + crmId);
                 response = httpServiceInvoker.execute(
                     url, HttpMethod.POST, objectMapper.writeValueAsString(crmIncidentPostRequest), isUpdate, "CRM");
-                    CrmIncidentPostResponse crmIncidentPostResponse = new CrmIncidentPostResponse(Integer.parseInt(crmId), String.valueOf(execution.getVariables().get("crmLookupName")));
+                CrmIncidentPostResponse crmIncidentPostResponse = new CrmIncidentPostResponse(Integer.parseInt(crmId), String.valueOf(execution.getVariables().get("crmLookupName")));
+                // Sending an email by calling /incidentReponse endpoint
+                CrmIdObject crmIncident = new CrmIdObject(Integer.parseInt(crmId));
+                CrmIncidentPatchRequest crmIncidentPatchRequest = new CrmIncidentPatchRequest(crmIncident, true);
+                url = getEndpointUrl("incidentResponse");
+                ResponseEntity<String> patchResponse = httpServiceInvoker.execute(
+                    url, HttpMethod.POST, objectMapper.writeValueAsString(crmIncidentPatchRequest), isUpdate, "CRM");
+                
                 return crmIncidentPostResponse;
             } else {
                 response = httpServiceInvoker.execute(

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmIncidentPatchRequest.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/model/CrmIncidentPatchRequest.java
@@ -1,0 +1,29 @@
+package main.java.org.camunda.bpm.extension.hooks.model;
+
+import java.util.ArrayList;
+
+public class CrmIncidentPatchRequest {
+  private CrmIdObject crmIncident;
+  private Boolean crmUseEmailSignature;
+  
+  public CrmIncidentPatchRequest(CrmIdObject crmIncident, Boolean crmUseEmailSignature) {
+    this.crmIncident = crmIncident;
+    this.crmUseEmailSignature = true;
+  }
+
+  public CrmIdObject getIncident() {
+    return crmIncident;
+  }
+
+  public void setIncident(CrmIdObject crmIncident) {
+    this.crmIncident = crmIncident;
+  }
+
+  public Boolean getUseEmailSignature() {
+    return crmUseEmailSignature;
+  }
+
+  public void setUseEmailSignature(Boolean crmUseEmailSignature) {
+    this.crmUseEmailSignature = crmUseEmailSignature;
+  }
+}


### PR DESCRIPTION
## Summary

DGJ-1381 send an email to supervisor when CRM ticket update

## Changes
- Call `/incidentReponse` endpoint to update CRM incident with send email configuration
- Keeping existing update flow as it is, because `/incidentReponse` does not support status and contact param


## Notes
NA