### PR TITLE
DGJ-1414 | add warning bg color

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -1033,6 +1033,9 @@ a{
 .info-background {
   background-color: #FFDBDB;
 }
+.warning-background {
+  background-color: #F9F1C6;
+}
 
 @media print {
 


### PR DESCRIPTION
 - The previous bg color is white. Changing this to be same as warning yellow color.
 - Also need to add the class to the form.

## Previous
![image](https://github.com/bcgov/digital-journeys/assets/146475472/0190c477-27eb-4bbd-8328-dabf350f2101)

## After Fix
![image](https://github.com/bcgov/digital-journeys/assets/146475472/562edf2a-8d1d-426b-abb0-a15d443919e1)
