### PR TITLE
DGJ_1484-improve-initial-submission-error-handling

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/draft.py
+++ b/forms-flow-api/src/formsflow_api/models/draft.py
@@ -56,7 +56,8 @@ class Draft(AuditDateTimeMixin, BaseModel, db.Model):
         self.commit()
 
     @classmethod
-    def get_by_id(cls, draft_id: str, user_id: str) -> Draft:
+    def get_by_id(cls, draft_id: str, user_id: str, 
+                  draft_status: DraftStatus = DraftStatus.ACTIVE) -> Draft:
         """Retrieves the draft entry by id."""
         result = (
             cls.query.join(Application, Application.id == cls.application_id)
@@ -66,7 +67,7 @@ class Draft(AuditDateTimeMixin, BaseModel, db.Model):
             )
             .filter(
                 and_(
-                    cls.status == str(DraftStatus.ACTIVE.value),
+                    cls.status == str(draft_status.value),
                     Application.created_by == user_id,
                     cls.id == draft_id,
                 )
@@ -157,6 +158,8 @@ class Draft(AuditDateTimeMixin, BaseModel, db.Model):
         """Activates the application from the draft entry."""
         # draft = cls.query.get(draft_id)
         draft = cls.get_by_id(draft_id, user_id)
+        # Storing and later returning original draft.data to later un-submit the draft in case something goes wrong on the Camunda workflow side
+        draft_data = draft.data
         if not draft:
             return None
         stmt = (
@@ -170,7 +173,7 @@ class Draft(AuditDateTimeMixin, BaseModel, db.Model):
         cls.execute(stmt)
         # The update statement will be commited by the following update
         draft.update({"status": DraftStatus.INACTIVE.value, "data": {}})
-        return draft
+        return draft, draft_data
 
     @classmethod
     def filter_conditions(cls, **filters):
@@ -216,3 +219,23 @@ class Draft(AuditDateTimeMixin, BaseModel, db.Model):
         )
         draft_count = query.count()
         return draft_count
+    
+    @classmethod
+    def un_make_submission(cls, draft_id, data, user_id, original_draft_data):
+        """Un-activates the application from the draft entry."""
+        # draft = cls.query.get(draft_id)
+        draft = cls.get_by_id(draft_id, user_id, DraftStatus.INACTIVE)
+        if not draft:
+            return None
+        stmt = (
+            update(Application)
+            .where(Application.id == draft.application_id)
+            .values(
+                application_status=data["application_status"],
+                submission_id=data["submission_id"],
+            )
+        )
+        cls.execute(stmt)
+        # The update statement will be commited by the following update
+        draft.update({"status": DraftStatus.ACTIVE.value, "data": original_draft_data})
+        return draft

--- a/forms-flow-api/src/formsflow_api/resources/application.py
+++ b/forms-flow-api/src/formsflow_api/resources/application.py
@@ -442,6 +442,9 @@ class ApplicationResourcesByIds(Resource):
             current_app.logger.warning(response)
             current_app.logger.warning(err)
             return response, status
+        # This will capture issues regarding the Camunda start process/task
+        except Exception as unexpected_error:
+            raise unexpected_error
         except BaseException as application_err:  # pylint: disable=broad-except
             response, status = {
                 "type": "Bad request error",

--- a/forms-flow-api/src/formsflow_api/resources/draft.py
+++ b/forms-flow-api/src/formsflow_api/resources/draft.py
@@ -184,7 +184,7 @@ class DraftSubmissionResource(Resource):
             current_app.logger.warning(err)
             error, status = err.error, err.status_code
             return error, status
-
+        # This will capture issues regarding the Camunda start process/task
         except Exception as unexpected_error:
             raise unexpected_error
 

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -95,6 +95,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
                 "error": camunda_error,
             }
             current_app.logger.critical(response)
+            raise Exception("Camunda workflow not able to create a task")
 
     @staticmethod
     @user_context
@@ -127,7 +128,15 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
             payload = ApplicationService.get_start_task_payload(
                 application, mapper, form_url, web_form_url, token
             )
-            ApplicationService.start_task(mapper, payload, token, application)
+            try:
+                ApplicationService.start_task(mapper, payload, token, application)
+            except Exception as e:
+                # Deleting submission 
+                ApplicationService.delete_submission_by_application(application)
+                ApplicationService.delete_application(application.id)
+                print("exception catched at create_application after ApplicationService.start_task")
+                raise
+
         return application, HTTPStatus.CREATED
 
     @staticmethod

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -134,7 +134,6 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
                 # Deleting submission 
                 ApplicationService.delete_submission_by_application(application)
                 ApplicationService.delete_application(application.id)
-                print("exception catched at create_application after ApplicationService.start_task")
                 raise
 
         return application, HTTPStatus.CREATED


### PR DESCRIPTION
## Summary

This PR improves the initial submission error handling and ensure no unnecessary data is created and draft is preserved  when submission failed because of an issue in Camunda and workflow start. Ticket #1484 

## Changes

- webApi: Draft resource, service, and model were updated to handle the Camunda workflow start issue.
- webApi: Application resource and service were updated to address the Camunda workflow start issue.
- webApi: The original user draft is preserved in case of a Camunda workflow start issue.
- webApi: The application is reverted back to draft status in case of a Camunda workflow start issue.
- webApi: Formio submission is deleted in case of a Camunda workflow start issue.