### PR TITLE
DGJ-1572 | remove li tag in Denied Page

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
+++ b/forms-flow-web/src/components/Form/Item/Submission/Success/SuccessPage.js
@@ -527,15 +527,11 @@ export default React.memo(() => {
       return (
         <>
           <span className="success-content-intro">Leave Denied</span>
-          <div className="success-content-body">
-            <ol>
-              <li>
-                Please inform the employee the reason for denial. If they still
-                want to go on leave, the employee must resubmit the form.
-                Employees can access the form in the &quot;Submitted forms&quot;
-                tab.
-              </li>
-            </ol>
+          <div className="success-content-body">                          
+              Please inform the employee the reason for denial. If they still
+              want to go on leave, the employee must resubmit the form.
+              Employees can access the form in the &quot;Submitted forms&quot;
+              tab.              
           </div>
         </>
       );


### PR DESCRIPTION
## Summary

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

- Removed the list style in Denied Page.
- Simply remove `ol` and `li` tags.
From Old:
![image](https://github.com/bcgov/digital-journeys/assets/146475472/1c4ff870-b202-4302-813e-2bf88de016ab)

To New:
![image](https://github.com/bcgov/digital-journeys/assets/146475472/b79419b5-3adc-47b0-aec5-6f19338cb1fd)
