### PR TITLE
DGJ-1501 | disable console.warn in the function

### DIFF
--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -135,6 +135,11 @@ const ServiceFlowTaskDetails = React.memo(() => {
       Formio.clearCache();
       dispatch(resetFormData("form"));
       function fetchForm() {
+        /* #1501 getForm generated lots of unnecessary console warning, 
+           use the following to disable console.warn
+        */
+        console.warn = () => {};
+
         dispatch(
           getForm("form", formId, (err) => {
             if (!err) {

--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -134,12 +134,7 @@ const ServiceFlowTaskDetails = React.memo(() => {
       const { formId, submissionId } = getFormIdSubmissionIdFromURL(formUrl);
       Formio.clearCache();
       dispatch(resetFormData("form"));
-      function fetchForm() {
-        /* #1501 getForm generated lots of unnecessary console warning, 
-           use the following to disable console.warn
-        */
-        console.warn = () => {};
-
+      function fetchForm() {        
         dispatch(
           getForm("form", formId, (err) => {
             if (!err) {
@@ -174,9 +169,20 @@ const ServiceFlowTaskDetails = React.memo(() => {
   );
 
   useEffect(() => {
+    const originalConsoleWarn = console.warn;
+    
     if (task?.formUrl) {
+      /* #1501 getForm generated lots of unnecessary console warning, 
+           use the following to disable console.warn
+        */      
+      console.warn = () => {};
+
       dispatch(setFormSubmissionLoading(true));
       getFormSubmissionData(task?.formUrl);
+    }
+
+    return () => {
+      console.warn = originalConsoleWarn;
     }
   }, [task?.formUrl, dispatch, getFormSubmissionData]);
 


### PR DESCRIPTION
## Summary

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

- Remove unnecessary console.warn
- After digging the code for a while, `console.warn` is happening in formio source code `getForm`, so nothing we can do but put the `console.warn` to be empty function in that scope, not effecting the global scope. I believe this is the best way for this case.

https://github.com/formio/react/blob/master/src/modules/form/actions.js

![image](https://github.com/bcgov/digital-journeys/assets/146475472/f76b1c5e-cdd4-413b-b5a8-6078f025bdc0)
