### PR TITLE
Remove margin for hidden alert components

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -937,6 +937,7 @@ header span:hover {
 .alert-bc-info.formio-hidden,
 .alert-bc-warning.formio-hidden {
   padding: 0;
+  margin: 0;
   background-color: transparent;
   &:before {
     margin-right: 11px;


### PR DESCRIPTION
Removes margin for hidden alert components so that they do not take create excess whitespace.