### PR TITLE
DGJ-1652 | Cold/Flu | Admin user can edit on "submitted" page.

### DIFF
--- a/forms-flow-web/src/constants/formConstants.js
+++ b/forms-flow-web/src/constants/formConstants.js
@@ -3,7 +3,7 @@ export const FORM_NAMES = {
     SENIOR_LEADER_REVIEW: 'Senior Leadership Review Form',
     TELEWORK: 'Telework agreement',
     COMPLIANT_1_10: 'Bullying / Misuse of Authority Complaint Form (Article 1.10)',
-    INFLUENZA_WORKSITE_REGISTRATION: '2023 Influenza Worksite Registration',
+    INFLUENZA_WORKSITE_REGISTRATION: '2024 Influenza Worksite Clinic Registration',
     MATERNITY_AND_PARENTAL_LEAVE_FORM: 'Maternity and parental leave form',
     MATERNITY_PARENTAL_LEAVE_AND_ALLOWANCE_FORM: 'Maternity, Parental Leave and Allowance form'
   };


### PR DESCRIPTION
- Fix the constant text and then it will show "Edit" button on submitted page.
- This line did include cold-flu-admin to show all applications on submitted page, so we don't need to add more.
![CleanShot 2024-03-05 at 07 59 16@2x](https://github.com/bcgov/digital-journeys/assets/146475472/d21943e4-9a11-47fa-8397-3d7fa9000988)

