### PR TITLE
DGJ-1352 | Snowplow further fix | fix duplicate call; add linkTracking

### DIFF
--- a/forms-flow-web/package.json
+++ b/forms-flow-web/package.json
@@ -42,6 +42,7 @@
     "@button-inc/component-library": "^1.0.1",
     "@material-ui/core": "^4.11.4",
     "@ronchalant/react-loading-overlay": "^1.1.0",
+    "@snowplow/browser-plugin-link-click-tracking": "^3.23.0",
     "@snowplow/browser-tracker": "^3.23.0",
     "@wojtekmaj/react-daterange-picker": "^3.1.0",
     "axios": "^0.21.4",

--- a/forms-flow-web/src/customHooks/useSnowPlow.js
+++ b/forms-flow-web/src/customHooks/useSnowPlow.js
@@ -3,7 +3,10 @@ import {
   trackPageView,
   enableActivityTracking,
 } from "@snowplow/browser-tracker";
-import { refreshLinkClickTracking, enableLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
+import {
+  refreshLinkClickTracking,
+  enableLinkClickTracking,
+} from "@snowplow/browser-plugin-link-click-tracking";
 import React from "react";
 import { useLocation } from "react-router-dom";
 
@@ -42,8 +45,8 @@ const useLocationChange = () => {
 const useSnowPlow = () => {
   React.useEffect(() => {
     const isInit = isTrackerInitialized();
-    if (!isInit) {      
-      initializeTracker(COLLECTOR);      
+    if (!isInit) {
+      initializeTracker(COLLECTOR);
     }
   }, []);
 

--- a/forms-flow-web/src/customHooks/useSnowPlow.js
+++ b/forms-flow-web/src/customHooks/useSnowPlow.js
@@ -3,6 +3,7 @@ import {
   trackPageView,
   enableActivityTracking,
 } from "@snowplow/browser-tracker";
+import { refreshLinkClickTracking, enableLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 import React from "react";
 import { useLocation } from "react-router-dom";
 
@@ -20,10 +21,13 @@ const initializeTracker = (endpoint) => {
     contexts: { webPage: true, performanceTiming: true },
   });
 
+  // plugins
   enableActivityTracking({
     minimumVisitLength: 30,
     heartbeatDelay: 30,
   });
+  enableLinkClickTracking({ pseudoClicks: true });
+  refreshLinkClickTracking();
 };
 
 const isTrackerInitialized = () => tracker !== undefined;
@@ -39,8 +43,7 @@ const useSnowPlow = () => {
   React.useEffect(() => {
     const isInit = isTrackerInitialized();
     if (!isInit) {      
-      initializeTracker(COLLECTOR);
-      trackPageView();
+      initializeTracker(COLLECTOR);      
     }
   }, []);
 


### PR DESCRIPTION
Had the meeting with Dan and Warren.
There are 2 issue we need to resolve:

Refer to comments on zenhub: https://app.zenhub.com/workspaces/digital-journeys-61c10fe84c8bcb001491c5f5/issues/gh/bcgov/digital-journeys/1352

- Bug: duplicate call at beginning when page load at first time.

Fixed: no duplicate call.
![CleanShot 2024-05-10 at 11 20 58](https://github.com/bcgov/digital-journeys/assets/146475472/a0f4e9cd-45c6-4b13-a67e-d6e2ddb1979f)


- Enhancement: add 'refreshLinkClickTracking' , then snowplow will know user is clinking on the "link". can use gov page to know what is correct behaviour.
Ref: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracking-events/link-click/#refresh-link-click-tracking

Fixed: now you can see purple color, meaning user click on the `<a />` tag.
![CleanShot 2024-05-10 at 11 22 21](https://github.com/bcgov/digital-journeys/assets/146475472/df805a8d-8951-4a4d-8d90-f6ca90d64823)



