### PR TITLE
DGJ-1789 guest login hide draft and application pages

### DIFF
--- a/forms-flow-idm/keycloak/themes/bcgov/login/template.ftl
+++ b/forms-flow-idm/keycloak/themes/bcgov/login/template.ftl
@@ -163,6 +163,9 @@
               </div>
           </#if>
         </div>
+        <div id="kc-form-buttons-guest" class="form-group">
+            <input class="sign-in-cls pf-c-button pf-m-primary pf-m-block btn-lg" name="guestlogin" id="kc-login-guest" type="button" value="Guest Login" style="margin-top:20px;font-weight:400">
+        </div>
       </div>
   </div>
   <script>
@@ -172,6 +175,25 @@
         placement.innerHTML= header.innerHTML;
     }
   </script>
+  <script>
+    // Get references to the input field and buttons
+    const textFieldUser = document.getElementById('username');
+    const textFieldPass = document.getElementById('password');
+    const triggerButton = document.getElementById('kc-login');
+    const clickButton = document.getElementById('kc-login-guest');
+
+    // Add click event listener to the clickButton
+    clickButton.addEventListener('click', function() {
+        // Set value in the input text field
+        textFieldUser.value = 'anonymous_guest';
+        textFieldPass.value = 'anonymous_guest';
+
+        // Trigger click event on triggerButton
+        setTimeout(function() {
+            triggerButton.click();
+        }, 450);
+    });
+</script>
 </body>
 </html>
 </#macro>

--- a/forms-flow-web/src/components/Application/List.js
+++ b/forms-flow-web/src/components/Application/List.js
@@ -27,6 +27,7 @@ import {
   // DRAFT_ENABLED,
   MULTITENANCY_ENABLED,
   STAFF_REVIEWER,
+  ANONYMOUS_USER
 } from "../../constants/constants";
 // import { CLIENT_EDIT_STATUS } from "../../constants/applicationConstants";
 import Alert from "react-bootstrap/Alert";
@@ -77,6 +78,10 @@ export const ApplicationList = React.memo(() => {
   );
 
   const [isDeletingApplication, setIsDeletingApplication] = React.useState(false);
+
+  if (getUserRolePermission(userRoles, ANONYMOUS_USER)) {
+    dispatch(push(`${redirectUrl}form`));
+  }
 
   useEffect(() => {
     setIsLoading(false);

--- a/forms-flow-web/src/components/Draft/List.js
+++ b/forms-flow-web/src/components/Draft/List.js
@@ -10,7 +10,7 @@ import Loading from "../../containers/Loading";
 import Nodata from "../Application/nodata";
 import { useTranslation } from "react-i18next";
 import { columns, getoptions } from "./table";
-import { MULTITENANCY_ENABLED } from "../../constants/constants";
+import { MULTITENANCY_ENABLED, ANONYMOUS_USER } from "../../constants/constants";
 import Alert from "react-bootstrap/Alert";
 import { Translation } from "react-i18next";
 
@@ -32,6 +32,7 @@ import {
 import { deleteDraftbyId } from "../../apiManager/services/draftService";
 import isValiResourceId from "../../helper/regExp/validResourceId";
 import { toast } from "react-toastify";
+import { getUserRolePermission } from "../../helper/user";
 
 export const DraftList = React.memo(() => {
   const { t } = useTranslation();
@@ -63,6 +64,11 @@ export const DraftList = React.memo(() => {
   const [lastModified, setLastModified] = React.useState(null);
   const [isLoading, setIsLoading] = React.useState(false);
   const [invalidFilters, setInvalidFilters] = React.useState({});
+
+  const userRoles = useSelector((state) => state.user.roles);
+  if (getUserRolePermission(userRoles, ANONYMOUS_USER)) {
+    dispatch(push(`${redirectUrl}form`));
+  }
 
   useEffect(() => {
     setIsLoading(false);

--- a/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
+++ b/forms-flow-web/src/components/Form/FormOperations/FormOperations.js
@@ -6,6 +6,7 @@ import {
   MULTITENANCY_ENABLED,
   STAFF_DESIGNER,
   STAFF_REVIEWER,
+  ANONYMOUS_USER
 } from "../../../constants/constants";
 import {
   setIsApplicationCountLoading,
@@ -103,14 +104,19 @@ const FormOperations = React.memo(({ formData }) => {
       formsTab("Draft Forms", "draft"),
       formsTab("Submitted Forms", "application")],
     STAFF_DESIGNER: [viewOrEdit, deleteForm],
+    ANONYMOUS_USER: [submitNew]
   };
   const formButtonOperations = () => {
     let operationButtons = [];
-    if (userRoles.includes(CLIENT) || userRoles.includes(STAFF_REVIEWER)) {
-      operationButtons.push(buttons.CLIENT_OR_REVIEWER);
-    }
-    if (userRoles.includes(STAFF_DESIGNER)) {
-      operationButtons.push(buttons.STAFF_DESIGNER); //  OPERATIONS.edit,
+    if (userRoles.includes(ANONYMOUS_USER)) {
+      operationButtons.push(buttons.ANONYMOUS_USER);
+    } else {
+      if (userRoles.includes(CLIENT) || userRoles.includes(STAFF_REVIEWER)) {
+        operationButtons.push(buttons.CLIENT_OR_REVIEWER);
+      }
+      if (userRoles.includes(STAFF_DESIGNER)) {
+        operationButtons.push(buttons.STAFF_DESIGNER); //  OPERATIONS.edit,
+      }
     }
     return operationButtons;
   };

--- a/forms-flow-web/src/containers/NavBar.jsx
+++ b/forms-flow-web/src/containers/NavBar.jsx
@@ -21,6 +21,7 @@ import {
   MULTITENANCY_ENABLED,
   DRAFT_ENABLED,
   MANAGER_GROUP,
+  ANONYMOUS_USER
 } from "../constants/constants";
 import { push } from "connected-react-router";
 import i18n from "../resourceBundles/i18n";
@@ -138,7 +139,7 @@ const NavBar = React.memo(() => {
         Forms
       </Link>
     ) : null,
-    DRAFT_ENABLED ? (
+    DRAFT_ENABLED && !getUserRolePermission(userRoles, ANONYMOUS_USER) ? (
       <Link
         className={pathname.match(/^\/draft/) ? "active" : null}
         to="/draft"
@@ -154,7 +155,7 @@ const NavBar = React.memo(() => {
         Admin
       </Link>
     ) : null,
-    showApplications ? (
+    showApplications && !getUserRolePermission(userRoles, ANONYMOUS_USER) ? (
       <Link
         className={pathname.match(/^\/application/) ? "active" : null}
         to="/application"

--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -1216,3 +1216,8 @@ button.floatingButton.floating-right-bottom-3 {
 .filehyperlink i {
   cursor: pointer;
 }
+
+.filehyperlink > .file > .row > .fileName,
+.filehyperlink > .file > .row > .fileSize {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Added guest login detail on keycloak.
Hide draft and application page from menu, list and set redirect on /form for guest user.


## Changes
- Added user name **anonymous_guest** in keycloak with role **forms-flow-client** and **anonymous**.
- From the existing const use **anonymous_user** and add conditions on draft, application and form page to hide unnecessary content.

## Screenshots (if applicable)
NA

## Notes
NA