### PR TITLE
DGJ-1785 | always showing submission loading

### DIFF
--- a/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/ServiceTaskDetails.js
@@ -293,7 +293,7 @@ const ServiceFlowTaskDetails = React.memo(() => {
         {t("Select a task in the list.")}
       </Row>
     );
-  } else if (isTaskLoading) {
+  } else if (!isCustomFormSubmissionLoading && isTaskLoading) {
     return (
       <div className="service-task-details">
         <Loading />


### PR DESCRIPTION
## Summary
- To always show submission loading

## Solution
- I found that after fetching, `isTaskLoading` become `true`, and then will show 3-ball loader.
- so we add one more condition `!isCustomFormSubmissionLoading`
![CleanShot 2024-05-28 at 10 07 10](https://github.com/bcgov/digital-journeys/assets/146475472/a0514df1-d22a-42cf-a4f2-afed1f767619)

![CleanShot 2024-05-28 at 10 09 59](https://github.com/bcgov/digital-journeys/assets/146475472/50c4b51b-8b0e-47ff-9ca9-4afdc99ea345)

