### PR TITLE
DGJ-1897 Add provisional for custom username assignment in camunda

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/UserGroupAssignmentListener.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/UserGroupAssignmentListener.java
@@ -88,6 +88,11 @@ public class UserGroupAssignmentListener  extends BaseListener implements TaskLi
         String managerEmail = String.valueOf(execution.getVariables().get("managerEmail"));
         String managerUsername = managerEmail + "_idir";
         String groupPathToBeAdded = String.valueOf(this.groupPath.getValue(execution));
+        String givenUsername = String.valueOf(execution.getVariables().get("givenUsername"));
+
+        if (!givenUsername.isEmpty() && givenUsername != null && givenUsername != "" && givenUsername != "null") {
+            managerUsername = givenUsername;
+        }
         
         if (managerEmail == null || managerEmail.isEmpty() || 
             groupPathToBeAdded == null || groupPathToBeAdded.isEmpty()) {


### PR DESCRIPTION
## Summary

Added provision to pass username from form to assign manager group

## Changes
Added condition to pull user name to assign camunda group at time of user assignment task.

## Screenshots (if applicable)
NA

## Notes
NA