### PR TITLE
Enhance button alignment in wizard navigation for improved layout

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -213,6 +213,10 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
   flex-wrap: wrap;
   gap: 5px;
   margin: 0;
+  justify-content: space-between;
+  .btn-wizard-nav-next:only-child {
+    margin-left: auto;
+  }
 }
 .btn-wizard-nav-submit,
 .btn-wizard-nav-next,


### PR DESCRIPTION
Align wizard buttons so they are not bunched together.
Move "next" button to the right if it is the only child.
This will enable us to utilize the built in wizard nav buttons for the coi instead of custom, allowing navigation in view only mode.