### PR TITLE
Refactor wizard navigation styles for improved button alignment

### DIFF
--- a/forms-flow-web/src/styles.scss
+++ b/forms-flow-web/src/styles.scss
@@ -207,16 +207,15 @@ i.fa.fa-plus-square-o.text-muted, i.fa.fa-minus-square-o.text-muted {
 .formio-errors .error {
   color: $red;
 }
-.formio-wizard-nav-container 
-{
+.formio-wizard-nav-container {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
   margin: 0;
   justify-content: space-between;
-  .btn-wizard-nav-next:only-child {
-    margin-left: auto;
-  }
+}
+.formio-wizard-nav-container > li:only-child {
+  margin-left: auto;
 }
 .btn-wizard-nav-submit,
 .btn-wizard-nav-next,


### PR DESCRIPTION
Fix to align the wizard nav button on the first page, when there is only a single child (the first page next button).