### PR TITLE
Add flag to control CRM attachment generation in CrmDelegate

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/listeners/CrmDelegate.java
@@ -261,18 +261,33 @@ public class CrmDelegate extends BaseListener implements JavaDelegate {
             crmIncidentPostRequest.setAssignedTo(crmAssignedTo);
         }
         
-        ArrayList<CrmFileAttachment> formPdfAttachments = this.formPDFAttachInCRM(execution);
-        ArrayList<CrmFileAttachment> crmFileAttachments = this.crmAttachFiles(execution);
-        if (crmFileAttachments != null) {
-            if (formPdfAttachments != null) {
-                crmFileAttachments.addAll(formPdfAttachments);
+        // Check flag to determine if attachments should be generated
+        boolean generateCrmAttachment = true;
+        Object flagObj = execution.getVariable("generateCrmAttachment");
+        if (flagObj != null) {
+            if (flagObj instanceof Boolean) {
+                generateCrmAttachment = (Boolean) flagObj;
+            } else {
+                generateCrmAttachment = Boolean.parseBoolean(flagObj.toString());
             }
-            crmIncidentPostRequest.setFileAttachments(crmFileAttachments);
+        }
+
+        if (generateCrmAttachment) {
+            ArrayList<CrmFileAttachment> formPdfAttachments = this.formPDFAttachInCRM(execution);
+            ArrayList<CrmFileAttachment> crmFileAttachments = this.crmAttachFiles(execution);
+            if (crmFileAttachments != null) {
+                if (formPdfAttachments != null) {
+                    crmFileAttachments.addAll(formPdfAttachments);
+                }
+                crmIncidentPostRequest.setFileAttachments(crmFileAttachments);
+            } else {
+                System.out.println("No file attachment found for CRM in form");
+                if (formPdfAttachments != null) {
+                    crmIncidentPostRequest.setFileAttachments(formPdfAttachments);
+                }
+            }
         } else {
-            System.out.println("No file attachment found for CRM in form");
-            if (formPdfAttachments != null) {
-                crmIncidentPostRequest.setFileAttachments(formPdfAttachments);
-            }
+            System.out.println("Attachment generation skipped due to flag.");
         }
         
         String url = getEndpointUrl(INCIDENTS);


### PR DESCRIPTION
Added flag to prevent attachment in crm ticket.

The code checks for a process variable named generateCrmAttachment in camunda.
If this variable is set to false (as a Boolean or a String "false"), attachment generation is skipped.
If the variable is not set, the default is true and attachments are generated.